### PR TITLE
Add mechanism to evaluate systematic shifts.

### DIFF
--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -53,6 +53,16 @@ dataset_names = [
 for dataset_name in dataset_names:
     config_2018.add_dataset(campaign_2018.get_dataset(dataset_name))
 
+# register shifts
+config_2018.add_shift(name="nominal", id=0)
+config_2018.add_shift(name="tune_up", id=1, type="shape")
+config_2018.add_shift(name="tune_down", id=2, type="shape")
+config_2018.add_shift(name="hdamp_up", id=3, type="shape")
+config_2018.add_shift(name="hdamp_down", id=4, type="shape")
+config_2018.add_shift(name="jec_up", id=5, type="shape")
+config_2018.add_shift(name="jec_down", id=6, type="shape")
+
+
 # file merging values
 # key -> dataset -> files per branch (-1 or not present = all)
 config_2018.set_aux("file_merging", {

--- a/ap/config/constants.py
+++ b/ap/config/constants.py
@@ -5,8 +5,7 @@ Scinentific constants.
 """
 
 from scinum import Number, Correlation, REL
-
-from ap.util import DotDict
+from law.util import DotDict
 
 
 # misc

--- a/ap/util.py
+++ b/ap/util.py
@@ -59,19 +59,10 @@ def import_ROOT():
     return _ROOT
 
 
-class DotDict(dict):
-    """
-    Dictionary providing item access via attributes.
-    """
-
-    def __getattr__(self, attr):
-        return self[attr]
-
-    def copy(self):
-        return self.__class__(super(DotDict, self).copy())
-
-
 def create_random_name():
+    """
+    Returns a random string based on UUID v4.
+    """
     return str(uuid.uuid4())
 
 


### PR DESCRIPTION
This PR adds new base task, `ShiftTask`, between `ConfigTask` and `DatasetTask`. It handles the evaluation of systematic shifts with a new parameter `--shift`. I added a few dummy shifts to `config_2018` and a dummy implementation of `jec_{up,down}` to `SelectEvents`.

*Details*

- The `ShiftTask` goes between `ConfigTask` and `DatasetTask` since shifts are defined per config, and they can in principe be meaningful without a dataset. Also, considering `nominal` to be a shift ifself (although a special one), a dataset is always subject to a systematic and therefore a `DatasetTask` is always a `ShiftTask`.
- The mechanism to evaluate a shift for a task is actually based on two parameters: `--shift` and `--effective-shift`. The former one is to be used from the command line, e.g. in `law run SelectEvents --version v1 --branch 0 --shift hdamp_down`. The latter one, `effective_shift` is defined internally and should never be set manually. It is a parameter in the first place to make it easy to pass it from one task to another. E.g. when a shift "A" is requested via `--shift A` and the task does neither implement nor depend on it, it sets its effective shift to "nominal". But still, since the original shift is set to "A", it passes it upstream to its requirements from them to evaluate this decision on their own.

@uhh-cms/ag-schleper 