### PR TITLE
Add BundleExternalFiles task to external.py.

### DIFF
--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -100,6 +100,15 @@ config_2018.add_shift(name="jec_up", id=5, type="shape")
 config_2018.add_shift(name="jec_down", id=6, type="shape")
 add_aliases("jec", {"Jet_pt": "Jet_pt_{name}", "Jet_mass": "Jet_mass_{name}"})
 
+# external files
+config_2018.set_aux("external_files", {
+    "lumi": {
+        "golden": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt",  # noqa
+        "normtag": "/afs/cern.ch/user/l/lumipro/public/Normtags/normtag_PHYSICS.json",
+    },
+})
+
+
 # columns to keep after certain steps
 config_2018.set_aux("keep_columns", {
     "ReduceEvents": {

--- a/ap/tasks/external.py
+++ b/ap/tasks/external.py
@@ -215,6 +215,7 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
         # helper function to fetch generic files
         def fetch_file(src, counter=[0]):
             dst = os.path.join(tmp_dir.path, self.create_unique_basename(src))
+            src = src[0] if isinstance(src, tuple) else src
             if src.startswith(("http://", "https://")):
                 # download via wget
                 wget(src, dst)

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -41,6 +41,7 @@ class BaseTask(law.Task):
         # default to the version of the requested task class in the version map accessible through
         # the task instance
         if isinstance(getattr(cls, "version", None), luigi.Parameter) and "version" not in kwargs:
+            # TODO: maybe have this entire mechanism implemented by subclasses
             version_map = cls.get_version_map(inst)
             if version_map is not NotImplemented and cls.__name__ in version_map:
                 kwargs["version"] = version_map[cls.__name__]
@@ -71,8 +72,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         if analysis == "analysis_st":
             from ap.config.analysis_st import analysis_st
             return analysis_st
-        else:
-            raise ValueError(f"unknown analysis {analysis}")
+
+        raise ValueError(f"unknown analysis {analysis}")
 
     @classmethod
     def get_version_map(cls, task):


### PR DESCRIPTION
This PR adds a new task `BundleExternalFiles` to `external.py`. It picks up the external files defined in `config_inst.x.external_files` in any arbitrary structure and

- fetches all of them (local files and http(s) supported) into a local tmp directory,
- bundles that directory into a tar gz, and
- uploads them with replication.

In addition, tasks using external files should require this new task and can access localized files (after fetching the bundle again) via

```python
    def requires(self):
        return BundleExternalFiles.req(self)

    def run(self):
        bundle = self.requires()
        print(bundle.files.lumi.golden.path)
```

Closes #10 when merged.