### PR TITLE
changed allowed values in category axis to only leaf cat ids

### DIFF
--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -170,7 +170,7 @@ class MergeShiftedHistograms(DatasetTask, CalibratorsSelectorMixin, law.LocalWor
 
     # disable the shift parameter
     shift = None
-    effective_shift = None
+    # effective_shift = None
     allow_empty_shift = True
 
     def workflow_requires(self):

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -83,9 +83,9 @@ class CreateHistograms(DatasetTask, ProducersMixin, CalibratorsSelectorMixin, la
                 weight = sampleweight * events.LHEWeight.originalXWGTUP
 
                 # get all viable category ids (only leaf categories)
-                # cat_ids = []
-                # for cat in self.config_inst.get_leaf_categories():
-                #    cat_ids.append(cat.id)
+                cat_ids = []
+                for cat in self.config_inst.get_leaf_categories():
+                    cat_ids.append(cat.id)
 
                 # define & fill histograms
                 var_names = self.config_inst.variables.names()
@@ -95,9 +95,7 @@ class CreateHistograms(DatasetTask, ProducersMixin, CalibratorsSelectorMixin, la
                             var = self.config_inst.variables.get(var_name)
                             h_var = (
                                 hist.Hist.new
-                                # .IntCat(cat_ids, name="category")  # , growth=True)
-                                # quick fix to access categories correct in plot task
-                                .IntCat(range(0, 10), name="category")
+                                .IntCat(cat_ids, name="category")
                                 .StrCategory([], name="shift", growth=True)
                                 .Var(var.bin_edges, name=var_name, label=var.get_full_x_title())
                                 .Weight()

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -127,8 +127,7 @@ class Plotting(CalibratorsSelectorMixin, PlotMixin, law.LocalWorkflow, HTCondorW
 
                         # to access the correct bins in the IntCat axis, we need
                         # the position of the bins, not the id itself
-                        id_to_pos = {cat_id: i for i, cat_id in enumerate(h_in.axes["category"])}
-                        leaf_to_pos = [id_to_pos[k] for k in leaf_cats]
+                        leaf_to_pos = [hist.loc(i) for i in leaf_cats]
 
                         h_in = h_in[{"category": leaf_to_pos}]
                         h_in = h_in[{"category": sum}]
@@ -293,8 +292,7 @@ class PlotShifts(CalibratorsSelectorMixin, PlotMixin, law.LocalWorkflow, HTCondo
                     leaf_cats = [cat.id for cat in c.get_category(category).get_leaf_categories()]
 
                 # to access the correct bins in the IntCat axis, we need the position of the bins, not the id itself
-                id_to_pos = {cat_id: i for i, cat_id in enumerate(h_in.axes["category"])}
-                leaf_to_pos = [id_to_pos[k] for k in leaf_cats]
+                leaf_to_pos = [hist.loc(i) for i in leaf_cats]
 
                 h_in = h_in[{"category": leaf_to_pos}]
                 h_in = h_in[{"category": sum}]

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -274,6 +274,7 @@ class PlotShifts(CalibratorsSelectorMixin, PlotMixin, law.LocalWorkflow, HTCondo
         with self.publish_step("Hello from PlotShiftograms"):
             import matplotlib.pyplot as plt
             import mplhep
+            import hist
             plt.style.use(mplhep.style.CMS)
 
             c = self.config_inst

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -8,7 +8,6 @@ from itertools import product
 
 import law
 
-from ap.tasks.framework.base import ConfigTask
 from ap.tasks.framework.mixins import CalibratorsSelectorMixin, PlotMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms


### PR DESCRIPTION
To access the correct bin in an intCategory, one needs to provide the position of the bin instead of the value of the bin. This can be done by `hist.loc(i)`