### PR TITLE
Add calibrators for deterministic seeds

### DIFF
--- a/ap/calibration/seeds.py
+++ b/ap/calibration/seeds.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+
+"""
+Methods related to creating event and object seeds during calibration.
+"""
+
+import hashlib
+
+from ap.calibration import calibrator
+from ap.util import maybe_import, primes
+from ap.columnar_util import Route, get_ak_indices, set_ak_column, has_ak_column
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@calibrator(
+    uses={
+        # global columns for event seed
+        "event", "nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV",
+        # first-object columns for event seed
+        "Tau.jetIdx", "Tau.decayMode",
+        "Muon.jetIdx", "Muon.nStations",
+        "Jet.nConstituents", "Jet.nElectrons", "Jet.nMuons",
+    },
+    produces={"deterministic_seed"},
+)
+def deterministic_event_seeds(events, create_seed, **kwargs):
+    # start with a seed of the event number itself as the most sensitive integer
+    seed = create_seed(events.event)
+
+    # get global integers
+    global_fields = ["nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV"]
+    for i, f in enumerate(global_fields, 3):
+        seed = seed + primes[i] * (events[f] if f in events.fields else ak.num(events[f[1:]]))
+
+    # get first-object integers
+    object_fields = [
+        "Tau.jetIdx", "Tau.decayMode", "Muon.jetIdx", "Muon.nStations", "Jet.nConstituents",
+        "Jet.nElectrons", "Jet.nMuons",
+    ]
+    for i, f in enumerate(object_fields, i + 1):
+        values = events[Route(f).fields]
+        seed = seed + primes[i] * (ak.fill_none(ak.firsts(values, axis=1), -1) + 1)
+
+    # create and store them
+    seed = ak.Array(create_seed(seed))
+    set_ak_column(events, "deterministic_seed", seed)
+
+    # uniqueness test across the chunk for debugging
+    # n_events = len(seed)
+    # n_seeds = len(set(seed))
+    # match_text = "yes" if n_events == n_seeds else "NO !!!"
+    # print(f"events: {n_events}, unique seeds: {n_seeds}, match: {match_text}")
+
+    return events
+
+
+@deterministic_event_seeds.setup
+def deterministic_event_seeds_setup(self, task, inputs, call_kwargs, **kwargs):
+    # define the vectorized seed creation function once
+    # strategy:
+    #   1. Gather a selection of unambiguous integer features.
+    #   2. Multiply them with a vector of primes.
+    #   3. Use the resulting integer as an input to sha256 and hex-digest the result.
+    #   4. Reverse it and int-cast the leading 16 characters, leading to a 64 bit int.
+    def create_seed(n: int) -> int:
+        return int(hashlib.sha256(bytes(str(n), "utf-8")).hexdigest()[:-16:-1], base=16)
+
+    # store a vectorized version in the call_kwargs
+    call_kwargs["create_seed"] = np.vectorize(create_seed, otypes=[np.uint64])
+
+
+@calibrator(
+    uses={deterministic_event_seeds, "nJet"},
+    produces={"Jet.deterministic_seed"},
+)
+def deterministic_jet_seeds(events, create_seed, **kwargs):
+    # create the event seeds if not already present
+    if not has_ak_column(events, "deterministic_seed"):
+        events = deterministic_event_seeds(events, create_seed=create_seed, **kwargs)
+
+    # create the per jet seeds
+    jet_seed = events.deterministic_seed + primes[18] * get_ak_indices(events.Jet)
+    np_jet_seed = np.asarray(ak.flatten(jet_seed))
+    np_jet_seed[:] = create_seed(np_jet_seed)
+
+    # store them
+    set_ak_column(events, "Jet.deterministic_seed", jet_seed)
+
+    # uniqueness test across all jets in the chunk for debugging
+    # n_jets = ak.sum(ak.num(events.Jet, axis=1))
+    # n_seeds = len(set(np_jet_seed))
+    # match_text = "yes" if n_jets == n_seeds else "NO !!!"
+    # print(f"jets: {n_jets}, unique seeds: {n_seeds}, match: {match_text}")
+
+    return events
+
+
+@calibrator(
+    uses={deterministic_event_seeds, deterministic_jet_seeds},
+    produces={deterministic_event_seeds, deterministic_jet_seeds},
+)
+def deterministic_seeds(events, **kwargs):
+    # create the event seeds
+    events = deterministic_event_seeds(events, **kwargs)
+
+    # create the jet seeds
+    events = deterministic_jet_seeds(events, **kwargs)
+
+    return events

--- a/ap/calibration/test.py
+++ b/ap/calibration/test.py
@@ -4,8 +4,8 @@
 Calibration methods for testing purposes.
 """
 
-from ap.util import maybe_import
 from ap.calibration import calibrator
+from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
 
 np = maybe_import("numpy")

--- a/ap/production/test.py
+++ b/ap/production/test.py
@@ -4,8 +4,8 @@
 Column production methods for testing purposes.
 """
 
-from ap.util import maybe_import
 from ap.production import producer
+from ap.util import maybe_import
 
 ak = maybe_import("awkward")
 

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -4,8 +4,8 @@
 Selection methods for testing purposes.
 """
 
-from ap.util import maybe_import
 from ap.selection import selector, SelectionResult
+from ap.util import maybe_import
 
 ak = maybe_import("awkward")
 np = maybe_import("numpy")

--- a/ap/util.py
+++ b/ap/util.py
@@ -5,7 +5,7 @@ Collection of general helpers and utilities.
 """
 
 __all__ = [
-    "env_is_remote", "env_is_dev",
+    "env_is_remote", "env_is_dev", "primes",
     "DotDict", "MockModule",
     "maybe_import", "import_plt", "import_ROOT", "create_random_name", "expand_path", "real_path",
     "wget", "call_thread", "call_proc", "ensure_proxy", "dev_sandbox",
@@ -31,6 +31,15 @@ env_is_remote = law.util.flag_to_bool(os.getenv("AP_REMOTE_JOB", "0"))
 
 #: Boolean denoting whether the environment is used for development (based on ``AP_DEV``).
 env_is_dev = not env_is_remote and law.util.flag_to_bool(os.getenv("AP_DEV", "0"))
+
+#: List of the first 100 primes.
+primes = [
+    2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+    101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193,
+    197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307,
+    311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421,
+    431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541,
+]
 
 
 class DotDict(dict):

--- a/law.cfg
+++ b/law.cfg
@@ -17,7 +17,7 @@ ap.tasks.plotting
 
 [analysis]
 
-calibration_modules: ap.calibration.test
+calibration_modules: ap.calibration.{test,seeds}
 selection_modules: ap.selection.test
 production_modules: ap.production.{test,pileup}
 

--- a/setup.sh
+++ b/setup.sh
@@ -114,7 +114,7 @@ setup() {
         fi
         ap_make_venv_relocateable ap_dev
 
-        echo "timestamp $( date "timestamp +%s" )" > "$flag_file_sw"
+        echo "timestamp $( date "+%s" )" > "$flag_file_sw"
         echo "version prod $sw_version_prod" >> "$flag_file_sw"
         echo "version dev $sw_version_dev" >> "$flag_file_sw"
     else


### PR DESCRIPTION
This PR adds calibrator functions that create deterministic event and object seeds (currently only for jets), based on combining integer features with primes, hashing and hex-digesting. These seeds can e.g. be used in smearing methods already applied during calibration (e.g. JER) or later on. The algorithm is can be written in one-line, making it easy to adapt for potential other groups for sync purposes.

When merged, this closes #36.