### PR TITLE
Allow selection to produce columns, closes #44.

### DIFF
--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -33,9 +33,9 @@ def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Calla
 
 class SelectionResult(object):
     """
-    Lightweight class that wraps selection decisions (e.g. masks and new columns) and provides
-    convenience methods to merge them or to dump them into an awkward array. The resulting structure
-    looks like the following example:
+    Lightweight class that wraps selection decisions (e.g. event and object selection steps) and
+    provides convenience methods to merge them or to dump them into an awkward array. The resulting
+    structure looks like the following example:
 
     .. code-block:: python
 
@@ -56,13 +56,6 @@ class SelectionResult(object):
                 "muon": array,
                 ...
             },
-
-            "columns": {
-                # any structure of new columns to be added
-                "my_new_column_a": array,
-                "my_new_column_b": array,
-                ...
-            }
         }
 
     The fields can be configured through the *main*, *steps*, *objects* and *columns* keyword
@@ -84,20 +77,24 @@ class SelectionResult(object):
         main: Optional[Union[DotDict, dict]] = None,
         steps: Optional[Union[DotDict, dict]] = None,
         objects: Optional[Union[DotDict, dict]] = None,
-        columns: Optional[Union[DotDict, dict]] = None,
     ):
         super().__init__()
 
         # store fields
-        self.main = DotDict(main or {})
-        self.steps = DotDict(steps or {})
-        self.objects = DotDict(objects or {})
-        self.columns = DotDict(columns or {})
+        self.main = DotDict.wrap(main or {})
+        self.steps = DotDict.wrap(steps or {})
+        self.objects = DotDict.wrap(objects or {})
 
-    def __iadd__(self, other: "SelectionResult") -> "SelectionResult":
+    def __iadd__(self, other: Union["SelectionResult", None]) -> "SelectionResult":
         """
-        Adds the field of a *other* instance in-place.
+        Adds the field of an *other* instance in-place. When *None*, *this* instance is returned
+        unchanged.
         """
+        # do nothing if the other instance is none
+        if other is None:
+            return self
+
+        # type check
         if not isinstance(other, SelectionResult):
             raise TypeError(f"cannot add '{other}' to {self.__class__.__name__} instance")
 
@@ -105,18 +102,24 @@ class SelectionResult(object):
         self.main.update(other.main)
         self.steps.update(other.steps)
         self.objects.update(other.objects)
-        self.columns.update(other.columns)
 
         return self
 
-    def __add__(self, other: "SelectionResult") -> "SelectionResult":
+    def __add__(self, other: Union["SelectionResult", None]) -> "SelectionResult":
         """
-        Returns a new instance with all fields of *this* and an *other* instance merged.
+        Returns a new instance with all fields of *this* and an *other* instance merged. When
+        *None*, a copy of *this* instance is returned.
         """
         inst = self.__class__()
 
+        # add this instance
         inst += self
-        inst += other
+
+        # add the other instance if not none
+        if other is not None:
+            if not isinstance(other, SelectionResult):
+                raise TypeError(f"cannot add '{other}' to {self.__class__.__name__} instance")
+            inst += other
 
         return inst
 
@@ -129,7 +132,6 @@ class SelectionResult(object):
             {
                 "steps": ak.zip(self.steps),
                 "objects": ak.zip(self.objects, depth_limit=1),  # limit due to ragged axis 1
-                "columns": ak.zip(self.columns),
             },
         ))
 

--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -58,8 +58,8 @@ class SelectionResult(object):
             },
         }
 
-    The fields can be configured through the *main*, *steps*, *objects* and *columns* keyword
-    arguments. The following example creates the structure above.
+    The fields can be configured through the *main*, *steps* and *objects* keyword arguments. The
+    following example creates the structure above.
 
     .. code-block:: python
 
@@ -67,7 +67,6 @@ class SelectionResult(object):
             main={...},
             steps={"jet": array, "muon": array, ...}
             objects={"jet": array, "muon": array, ...}
-            columns={"my_new_column_a": array, "my_new_column_b": array, ...}
         )
         res.to_ak()
     """

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -1,492 +1,1 @@
-# coding: utf-8
-
-"""
-Selection methods for testing purposes.
-"""
-
-from typing import Callable, Dict, List, Optional, Union
-
-from ap.selection import selector, SelectionResult
-from ap.util import maybe_import
-from ap.columnar_util import set_ak_column
-
-ak = maybe_import("awkward")
-np = maybe_import("numpy")
-
-
-def extract(array, idx):
-    """
-    inputs jagged array and index and returns padded array from given index
-    """
-    array = ak.pad_none(array, idx + 1)
-    array = ak.fill_none(array[:, idx], -999)
-    return array
-
-
-# object definitions
-# TODO: Producer instead of Selector
-@selector(uses={"Jet.pt", "Jet.eta"})
-def req_jet(events):
-    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4)
-    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
-
-
-@selector(uses={"Electron.pt", "Electron.eta", "Electron.cutBased"})
-def req_electron(events):
-    mask = (events.Electron.pt > 25) & (abs(events.Electron.eta) < 2.4) & (events.Electron.cutBased == 4)
-    return ak.argsort(events.Electron.pt, axis=-1, ascending=False)[mask]
-
-
-@selector(uses={"Muon.pt", "Muon.eta", "Muon.tightId"})
-def req_muon(events):
-    mask = (events.Muon.pt > 25) & (abs(events.Muon.eta) < 2.4) & (events.Muon.tightId)
-    return ak.argsort(events.Muon.pt, axis=-1, ascending=False)[mask]
-
-
-@selector(uses={"Jet.pt", "Jet.eta"})
-def req_forwardJet(events):
-    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) > 2.4) & (abs(events.Jet.eta) < 5.0)
-    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
-
-
-@selector(uses={"Jet.pt", "Jet.eta", "Jet.btagDeepFlavB"})
-def req_deepjet(events):
-    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4) & (events.Jet.btagDeepFlavB > 0.3)
-    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
-
-
-# variables (after reducing events)
-# TODO: this should maybe be a producer
-@selector(
-    uses={
-        "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta", "Jet.pt", "Jet.eta",
-        "Jet.btagDeepFlavB",
-    },
-    produces={"HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt"} | {
-        f"Jet{i}_{attr}"
-        for i in range(1, 4 + 1)
-        for attr in ["pt", "eta"]
-    },
-)
-def variables(events):
-    set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))
-    for i in range(1, 4 + 1):
-        set_ak_column[events, f"Jet{i}_pt"] = extract(events.Jet.pt, i - 1)
-        set_ak_column[events, f"Jet{i}_eta"] = extract(events.Jet.eta, i - 1)
-    set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))
-    set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))
-    set_ak_column(events, "nMuon", ak.num(events.Muon.pt, axis=1))
-    set_ak_column(events, "nDeepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))
-    set_ak_column(events, "Electron1_pt", extract(events.Electron.pt, 0))
-    set_ak_column(events, "Muon1_pt", extract(events.Muon.pt, 0))
-
-    return None, events
-
-
-@selector(uses={req_jet})
-def var_nJet(events):
-    return ak.num(req_jet(events), axis=1)
-
-
-@selector(uses={req_deepjet})
-def var_nDeepjet(events):
-    return ak.num(req_deepjet(events), axis=1)
-
-
-@selector(uses={req_electron})
-def var_nElectron(events):
-    return ak.num(req_electron(events), axis=1)
-
-
-@selector(uses={req_muon})
-def var_nMuon(events):
-    return ak.num(req_muon(events), axis=1)
-
-
-@selector(uses={req_jet, "Jet.pt"})
-def var_HT(events):
-    jet_pt_sorted = events.Jet.pt[req_jet(events)]
-    return ak.sum(jet_pt_sorted, axis=1)
-
-
-# selection for the main categories
-@selector(uses={var_nMuon, var_nElectron})
-def sel_1e(events):
-    return (var_nMuon(events) == 0) & (var_nElectron(events) == 1)
-
-
-@selector(uses={var_nMuon, var_nElectron})
-def sel_1mu(events):
-    return (var_nMuon(events) == 1) & (var_nElectron(events) == 0)
-
-
-# selection for the sub-categories
-@selector(uses={sel_1e, var_nDeepjet})
-def sel_1e_eq1b(events):
-    return (sel_1e(events)) & (var_nDeepjet(events) == 1)
-
-
-@selector(uses={sel_1e, var_nDeepjet})
-def sel_1e_ge2b(events):
-    return (sel_1e(events)) & (var_nDeepjet(events) >= 2)
-
-
-@selector(uses={sel_1mu, var_nDeepjet})
-def sel_1mu_eq1b(events):
-    return (sel_1mu(events)) & (var_nDeepjet(events) == 1)
-
-
-@selector(uses={sel_1mu, var_nDeepjet})
-def sel_1mu_ge2b(events):
-    return (sel_1mu(events)) & (var_nDeepjet(events) >= 2)
-
-
-@selector(uses={sel_1mu_ge2b, var_HT})
-def sel_1mu_ge2b_lowHT(events):
-    return (sel_1mu_ge2b(events)) & (var_HT(events) <= 300)
-
-
-@selector(uses={sel_1mu_ge2b, var_HT})
-def sel_1mu_ge2b_highHT(events):
-    return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)
-
-
-"""
-# combination of all categories, taking categories from each level into account, not only leaf categories
-@selector(uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b, sel_1mu_ge2b_highHT, sel_1mu_ge2b_lowHT})
-def categories(events, config):
-    cat_titles = []# ["no_cat"]
-    cat_array = "no_cat"
-    mask_int = 0
-
-    def write_cat_array(events, categories, cat_titles, cat_array):
-        for cat in categories:
-            cat_titles.append(cat.name)
-            mask = globals()[cat.selection](events)
-            cat_array = np.where(mask, cat.name, cat_array)
-            if not cat.is_leaf_category:
-                cat_titles, cat_array = write_cat_array(events, cat.categories, cat_titles, cat_array)
-        return cat_titles, cat_array
-
-    cat_titles, cat_array = write_cat_array(events, config.categories, cat_titles, cat_array)
-    # TODO checks that categories are set up properly
-    return SelectionResult(
-        #columns={"cat_titles": cat_titles, "cat_array": cat_array}
-        columns={"cat_array": cat_array}
-    )
-"""
-
-
-# combination of all leaf categories
-@selector(
-    uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b},
-    produces={"cat_array"},
-)
-def categories(events, config_inst):
-    cat_array = 0
-    mask_int = 0
-    for cat in config_inst.get_leaf_categories():
-        cat_sel = cat.selection
-        mask = globals()[cat_sel](events)
-        cat_array = np.where(mask, cat.id, cat_array)
-        mask_int = mask_int + np.where(mask, 1, 0)  # to check orthogonality of categories
-    if not ak.all(mask_int == 1):
-        if ak.any(mask_int >= 2):
-            print("Leaf categories are not fully orthogonal")
-        else:
-            print("Some events are without leaf category")
-
-    set_ak_column(events, "cat_array", cat_array)
-
-    return None, events
-
-
-@selector(uses={req_jet}, produces={"jet_high_multiplicity"})
-def jet_selection_test(events, stats, **kwargs):
-    # example cuts:
-    # - require at least 4 jets with pt>30, eta<2.4
-    # example columns:
-    # - high jet multiplicity region (>=6 selected jets)
-
-    jet_indices = req_jet(events)
-    jet_sel = ak.num(jet_indices, axis=1) >= 4
-    jet_high_multiplicity = ak.num(jet_indices, axis=1) >= 6
-
-    set_ak_column(events, "jet_high_multiplicity", jet_high_multiplicity)
-
-    # build and return selection results plus new columns
-    return (
-        SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices}),
-        events,
-    )
-
-
-@selector(uses={req_deepjet})
-def deepjet_selection_test(events, stats):
-    deepjet_indices = req_deepjet(events)
-    deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1
-
-    return (
-        SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices}),
-        events,
-    )
-
-
-@selector(uses={req_muon})
-def muon_selection_test(events, stats):
-    # example cuts:
-    # - require exactly one muon with pt>25, eta<2.4 and tight Id
-
-    muon_indices = req_muon(events)
-    muon_sel = ak.num(muon_indices, axis=1) == 1
-
-    # build and return selection results
-    return (
-        SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices}),
-        events,
-    )
-
-
-@selector(uses={req_electron})
-def electron_selection_test(events, stats):
-    # example cuts:
-    # - require exactly one muon with pt>25, eta<2.4 and tight Id
-
-    electron_indices = req_electron(events)
-    electron_sel = ak.num(electron_indices, axis=1) == 1
-
-    # build and return selection results
-    return (
-        SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices}),
-        events,
-    )
-
-
-@selector(uses={req_muon, req_electron})
-def lepton_selection_test(events, stats):
-    # example cuts:
-    # - require exactly one lepton with pt>25, eta<2.4 and tight Id
-
-    muon_indices = req_muon(events)
-    electron_indices = req_electron(events)
-    lepton_sel = ak.num(muon_indices, axis=1) + ak.num(electron_indices, axis=1) == 1
-
-    # build and return selection results
-    return (
-        SelectionResult(
-            steps={"Lepton": lepton_sel},
-            objects={"Muon": muon_indices, "Electron": electron_indices},
-        ),
-        events,
-    )
-
-
-@selector(
-    uses={
-        jet_selection_test, lepton_selection_test, deepjet_selection_test,
-        "LHEWeight.originalXWGTUP",
-    },
-    produces={
-        categories,
-    },
-)
-def test(events, stats, config_inst, **kwargs):
-    # example cuts:
-    # - jet_selection_test
-    # - lepton_selection_test
-    # example stats:
-    # - number of events before and after selection
-    # - sum of mc weights before and after selection
-
-    # prepare the selection results that are updated at every step
-    results = SelectionResult()
-
-    # jet selection
-    jet_results, events = jet_selection_test(events, stats)
-    results += jet_results
-
-    # lepton selection
-    lepton_results, events = lepton_selection_test(events, stats)
-    results += lepton_results
-
-    # deep jet selection
-    deepjet_results, events = deepjet_selection_test(events, stats)
-    results += deepjet_results
-
-    # combined event selection after all steps
-    event_sel = jet_results.steps.Jet & lepton_results.steps.Lepton & deepjet_results.steps.Deepjet
-    results.main["event"] = event_sel
-
-    # include categories into results
-    category_results, events = categories(events, config_inst)
-    results += category_results
-
-    # increment stats
-    events_sel = events[event_sel]
-    stats["n_events"] += len(events)
-    stats["n_events_selected"] += ak.sum(event_sel, axis=0)
-    stats["sum_mc_weight"] += ak.sum(events.LHEWeight.originalXWGTUP)
-    stats["sum_mc_weight_selected"] += ak.sum(events_sel.LHEWeight.originalXWGTUP)
-
-    return results, events
-
-
-# deltaR cleaning
-
-
-def cleaning_factory(
-    selector_name: str,
-    to_clean: str,
-    clean_against: List[str],
-    metric: Optional[Callable] = None,
-) -> Callable:
-    """
-    factory to generate a function with name *selector_name* that cleans the
-    field *to_clean* in the NanoEventArrays agains the field(s) *clean_agains*.
-    First, the necessary column names to construct four-momenta for the
-    different object fields are constructed, i.e. pt, eta, phi and e for the
-    different objects.
-    Finally, the actual selector function is generated, which uses these
-    columns.
-    """
-    # default of the metric function is the delta_r function
-    # of the coffea LorentzVectors
-    if metric is None:
-        metric = lambda a, b: a.delta_r(b)
-
-    # compile the list of variables that are necessary for the four momenta
-    # this list is always the same
-    variables_for_lorentzvec = ["pt", "eta", "phi", "e"]
-
-    # sum up all fields aht are to be considered, i.e. the field *to_clean*
-    # and all fields in *clean_against*
-    all_fields = clean_against + [to_clean]
-
-    # construct the set of columns that is necessary for the four momenta in
-    # the different fields (and thus also for the current implementation of
-    # the cleaning itself) by looping through the fields and variables.
-
-    uses = {
-        f"{x}.{var}" for x in all_fields for var in variables_for_lorentzvec
-    }
-
-    # additionally, also load the lengths of the different fields
-    uses |= {f"n{x}" for x in all_fields}
-
-    # finally, construct selector function itself
-    @selector(uses=uses, name=selector_name)
-    def func(
-        events: ak.Array,
-        to_clean: str,
-        clean_against: List[str],
-        metric: Optional[Callable] = metric,
-        threshold: float = 0.4,
-    ) -> List[int]:
-        """
-        abstract function to perform a cleaning of field *to_clean* against
-        a (list of) field(s) *clean_against* based on an abitrary metric
-        *metric* (e.g. deltaR).
-        First concatenate all fields in *clean_against*, which thus includes
-        all fields that are to be used for the comparison of the metric.
-        Then construct the metric for all permutations of the different objects
-        using the coffea nearest implementation.
-        All objects in field *to_clean* are removed if the metric is below the
-        *threshold*.
-        """
-
-        # concatenate the fields that are to be used in the construction
-        # of the metric table
-        summed_clean_against = ak.concatenate(
-            [events[x] for x in clean_against],
-            axis=1,
-        )
-
-        # load actual NanoEventArray that is to be cleaned
-        to_clean_field = events[to_clean]
-
-        # construct metric table for these objects. The metric table contains
-        # the minimal value of the metric *metric* for each object in field
-        # *to_clean* w.r.t. all objects in *summed_clean_against*. Thus,
-        # it has the dimensions nevents x nto_clean, where *nevents* is
-        # the number of events in the current chunk of data and *nto_clean*
-        # is the length of the field *to_clean*. Note that the argument
-        # *threshold* in the *nearest* function must be set to None since
-        # the function will perform a selection itself to extract the nearest
-        # objects (i.e. applies the selection we want here in reverse)
-        _, metric = to_clean_field.nearest(
-            summed_clean_against,
-            metric=metric,
-            return_metric=True,
-            threshold=None,
-        )
-        # build a binary mask based on the selection threshold provided by the
-        # user
-        mask = metric > threshold
-
-        # construct final result. Currently, this is the list of indices for
-        # clean jets, sorted for pt
-        # WARNING: this still contains the bug with the application of the mask
-        #           which will be adressed in a PR in the very near future
-        # TODO: return the mask itself instead of the list of indices
-        sorted_list = ak.argsort(to_clean_field.pt, axis=-1, ascending=False)[mask]
-        return sorted_list
-
-    return func
-
-
-delta_r_jet_lepton = cleaning_factory(
-    selector_name="delta_r_jet_lepton",
-    to_clean="Jet",
-    clean_against=["Muon", "Electron"],
-    metric=lambda a, b: a.delta_r(b),
-)
-
-
-def req_clean_delta_r_match_jet_lepton(
-    events: ak.Array,
-    to_clean: str,
-    clean_against: List[str],
-    threshold: float = 0.4,
-) -> List[int]:
-    """
-    do the cleaning of jets with respect to leptons.
-    returns indices of good (clean) jets, sorted by pt
-    *TODO*: this should probably changed to return the boolean masks
-    """
-    return delta_r_jet_lepton(events, to_clean, clean_against, threshold=threshold)
-
-
-@selector(uses={delta_r_jet_lepton})
-def jet_lepton_delta_r_cleaning_selection(
-    events: ak.Array,
-    stats: Dict[str, Union[int, float]],
-    threshold: float = 0.4,
-) -> SelectionResult:
-    """
-    function to apply the selection requirements necessary for a
-    cleaning of jets against leptons.
-    The function calls the requirements to clean the field *Jet* against
-    the concatination of the fields *[Muon, Electron]*, i.e. all leptons
-    and passes the desired threshold for the selection
-    """
-    clean_jet_indices = req_clean_delta_r_match_jet_lepton(events, "Jet", ["Muon", "Electron"], threshold=threshold)
-
-    return SelectionResult(
-        objects={"Jet": clean_jet_indices},
-    )
-
-
-@selector(uses={jet_lepton_delta_r_cleaning_selection})
-def jet_lepton_delta_r_cleaning(
-    events: ak.Array,
-    stats: Dict[str, Union[int, float]],
-    threshold: float = 0.4,
-    **kwargs,
-) -> SelectionResult:
-    """
-    Selector function that performs cleaning of jets against leptons
-    based on a delta_r requirement
-    """
-    results = jet_lepton_delta_r_cleaning_selection(events, stats, threshold=threshold)
-
-    return results
+# coding: utf-8"""Selection methods for testing purposes."""from typing import Callable, Dict, List, Optional, Unionfrom ap.selection import selector, SelectionResultfrom ap.util import maybe_importfrom ap.columnar_util import set_ak_columnak = maybe_import("awkward")np = maybe_import("numpy")def extract(array, idx):    """    inputs jagged array and index and returns padded array from given index    """    array = ak.pad_none(array, idx + 1)    array = ak.fill_none(array[:, idx], -999)    return array# object definitions# TODO: Producer instead of Selector@selector(uses={"Jet.pt", "Jet.eta"})def req_jet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]@selector(uses={"Electron.pt", "Electron.eta", "Electron.cutBased"})def req_electron(events):    mask = (events.Electron.pt > 25) & (abs(events.Electron.eta) < 2.4) & (events.Electron.cutBased == 4)    return ak.argsort(events.Electron.pt, axis=-1, ascending=False)[mask]@selector(uses={"Muon.pt", "Muon.eta", "Muon.tightId"})def req_muon(events):    mask = (events.Muon.pt > 25) & (abs(events.Muon.eta) < 2.4) & (events.Muon.tightId)    return ak.argsort(events.Muon.pt, axis=-1, ascending=False)[mask]@selector(uses={"Jet.pt", "Jet.eta"})def req_forwardJet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) > 2.4) & (abs(events.Jet.eta) < 5.0)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]@selector(uses={"Jet.pt", "Jet.eta", "Jet.btagDeepFlavB"})def req_deepjet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4) & (events.Jet.btagDeepFlavB > 0.3)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]# variables (after reducing events)# TODO: this should maybe be a producer@selector(    uses={        "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta", "Jet.pt", "Jet.eta",        "Jet.btagDeepFlavB",    },    produces={"HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt"} | {        f"Jet{i}_{attr}"        for i in range(1, 4 + 1)        for attr in ["pt", "eta"]    },)def variables(events):    set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))    set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))    set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))    set_ak_column(events, "nMuon", ak.num(events.Muon.pt, axis=1))    set_ak_column(events, "nDeepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))    set_ak_column(events, "Electron1_pt", extract(events.Electron.pt, 0))    set_ak_column(events, "Muon1_pt", extract(events.Muon.pt, 0))    for i in range(1, 4 + 1):        set_ak_column(events, f"Jet{i}_pt", extract(events.Jet.pt, i - 1))        set_ak_column(events, f"Jet{i}_eta", extract(events.Jet.eta, i - 1))    return None, events@selector(uses={req_jet})def var_nJet(events):    return ak.num(req_jet(events), axis=1)@selector(uses={req_deepjet})def var_nDeepjet(events):    return ak.num(req_deepjet(events), axis=1)@selector(uses={req_electron})def var_nElectron(events):    return ak.num(req_electron(events), axis=1)@selector(uses={req_muon})def var_nMuon(events):    return ak.num(req_muon(events), axis=1)@selector(uses={req_jet, "Jet.pt"})def var_HT(events):    jet_pt_sorted = events.Jet.pt[req_jet(events)]    return ak.sum(jet_pt_sorted, axis=1)# selection for the main categories@selector(uses={var_nMuon, var_nElectron})def sel_1e(events):    return (var_nMuon(events) == 0) & (var_nElectron(events) == 1)@selector(uses={var_nMuon, var_nElectron})def sel_1mu(events):    return (var_nMuon(events) == 1) & (var_nElectron(events) == 0)# selection for the sub-categories@selector(uses={sel_1e, var_nDeepjet})def sel_1e_eq1b(events):    return (sel_1e(events)) & (var_nDeepjet(events) == 1)@selector(uses={sel_1e, var_nDeepjet})def sel_1e_ge2b(events):    return (sel_1e(events)) & (var_nDeepjet(events) >= 2)@selector(uses={sel_1mu, var_nDeepjet})def sel_1mu_eq1b(events):    return (sel_1mu(events)) & (var_nDeepjet(events) == 1)@selector(uses={sel_1mu, var_nDeepjet})def sel_1mu_ge2b(events):    return (sel_1mu(events)) & (var_nDeepjet(events) >= 2)@selector(uses={sel_1mu_ge2b, var_HT})def sel_1mu_ge2b_lowHT(events):    return (sel_1mu_ge2b(events)) & (var_HT(events) <= 300)@selector(uses={sel_1mu_ge2b, var_HT})def sel_1mu_ge2b_highHT(events):    return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)"""# combination of all categories, taking categories from each level into account, not only leaf categories@selector(uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b, sel_1mu_ge2b_highHT, sel_1mu_ge2b_lowHT})def categories(events, config):    cat_titles = []# ["no_cat"]    cat_array = "no_cat"    mask_int = 0    def write_cat_array(events, categories, cat_titles, cat_array):        for cat in categories:            cat_titles.append(cat.name)            mask = globals()[cat.selection](events)            cat_array = np.where(mask, cat.name, cat_array)            if not cat.is_leaf_category:                cat_titles, cat_array = write_cat_array(events, cat.categories, cat_titles, cat_array)        return cat_titles, cat_array    cat_titles, cat_array = write_cat_array(events, config.categories, cat_titles, cat_array)    # TODO checks that categories are set up properly    return SelectionResult(        #columns={"cat_titles": cat_titles, "cat_array": cat_array}        columns={"cat_array": cat_array}    )"""# combination of all leaf categories@selector(    uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b},    produces={"cat_array"},)def categories(events, config_inst):    cat_array = 0    mask_int = 0    for cat in config_inst.get_leaf_categories():        cat_sel = cat.selection        mask = globals()[cat_sel](events)        cat_array = np.where(mask, cat.id, cat_array)        mask_int = mask_int + np.where(mask, 1, 0)  # to check orthogonality of categories    if not ak.all(mask_int == 1):        if ak.any(mask_int >= 2):            print("Leaf categories are not fully orthogonal")        else:            print("Some events are without leaf category")    set_ak_column(events, "cat_array", cat_array)    return None, events@selector(uses={req_jet}, produces={"jet_high_multiplicity"})def jet_selection_test(events, stats, **kwargs):    # example cuts:    # - require at least 4 jets with pt>30, eta<2.4    # example columns:    # - high jet multiplicity region (>=6 selected jets)    jet_indices = req_jet(events)    jet_sel = ak.num(jet_indices, axis=1) >= 4    jet_high_multiplicity = ak.num(jet_indices, axis=1) >= 6    set_ak_column(events, "jet_high_multiplicity", jet_high_multiplicity)    # build and return selection results plus new columns    return (        SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices}),        events,    )@selector(uses={req_deepjet})def deepjet_selection_test(events, stats):    deepjet_indices = req_deepjet(events)    deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1    return (        SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices}),        events,    )@selector(uses={req_muon})def muon_selection_test(events, stats):    # example cuts:    # - require exactly one muon with pt>25, eta<2.4 and tight Id    muon_indices = req_muon(events)    muon_sel = ak.num(muon_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices}),        events,    )@selector(uses={req_electron})def electron_selection_test(events, stats):    # example cuts:    # - require exactly one muon with pt>25, eta<2.4 and tight Id    electron_indices = req_electron(events)    electron_sel = ak.num(electron_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices}),        events,    )@selector(uses={req_muon, req_electron})def lepton_selection_test(events, stats):    # example cuts:    # - require exactly one lepton with pt>25, eta<2.4 and tight Id    muon_indices = req_muon(events)    electron_indices = req_electron(events)    lepton_sel = ak.num(muon_indices, axis=1) + ak.num(electron_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(            steps={"Lepton": lepton_sel},            objects={"Muon": muon_indices, "Electron": electron_indices},        ),        events,    )@selector(    uses={        jet_selection_test, lepton_selection_test, deepjet_selection_test,        "LHEWeight.originalXWGTUP",    },    produces={        categories,    },)def test(events, stats, config_inst, **kwargs):    # example cuts:    # - jet_selection_test    # - lepton_selection_test    # example stats:    # - number of events before and after selection    # - sum of mc weights before and after selection    # prepare the selection results that are updated at every step    results = SelectionResult()    # jet selection    jet_results, events = jet_selection_test(events, stats)    results += jet_results    # lepton selection    lepton_results, events = lepton_selection_test(events, stats)    results += lepton_results    # deep jet selection    deepjet_results, events = deepjet_selection_test(events, stats)    results += deepjet_results    # combined event selection after all steps    event_sel = jet_results.steps.Jet & lepton_results.steps.Lepton & deepjet_results.steps.Deepjet    results.main["event"] = event_sel    # include categories into results    category_results, events = categories(events, config_inst)    results += category_results    # increment stats    events_sel = events[event_sel]    stats["n_events"] += len(events)    stats["n_events_selected"] += ak.sum(event_sel, axis=0)    stats["sum_mc_weight"] += ak.sum(events.LHEWeight.originalXWGTUP)    stats["sum_mc_weight_selected"] += ak.sum(events_sel.LHEWeight.originalXWGTUP)    return results, events# deltaR cleaningdef cleaning_factory(    selector_name: str,    to_clean: str,    clean_against: List[str],    metric: Optional[Callable] = None,) -> Callable:    """    factory to generate a function with name *selector_name* that cleans the    field *to_clean* in the NanoEventArrays agains the field(s) *clean_agains*.    First, the necessary column names to construct four-momenta for the    different object fields are constructed, i.e. pt, eta, phi and e for the    different objects.    Finally, the actual selector function is generated, which uses these    columns.    """    # default of the metric function is the delta_r function    # of the coffea LorentzVectors    if metric is None:        metric = lambda a, b: a.delta_r(b)    # compile the list of variables that are necessary for the four momenta    # this list is always the same    variables_for_lorentzvec = ["pt", "eta", "phi", "e"]    # sum up all fields aht are to be considered, i.e. the field *to_clean*    # and all fields in *clean_against*    all_fields = clean_against + [to_clean]    # construct the set of columns that is necessary for the four momenta in    # the different fields (and thus also for the current implementation of    # the cleaning itself) by looping through the fields and variables.    uses = {        f"{x}.{var}" for x in all_fields for var in variables_for_lorentzvec    }    # additionally, also load the lengths of the different fields    uses |= {f"n{x}" for x in all_fields}    # finally, construct selector function itself    @selector(uses=uses, name=selector_name)    def func(        events: ak.Array,        to_clean: str,        clean_against: List[str],        metric: Optional[Callable] = metric,        threshold: float = 0.4,    ) -> List[int]:        """        abstract function to perform a cleaning of field *to_clean* against        a (list of) field(s) *clean_against* based on an abitrary metric        *metric* (e.g. deltaR).        First concatenate all fields in *clean_against*, which thus includes        all fields that are to be used for the comparison of the metric.        Then construct the metric for all permutations of the different objects        using the coffea nearest implementation.        All objects in field *to_clean* are removed if the metric is below the        *threshold*.        """        # concatenate the fields that are to be used in the construction        # of the metric table        summed_clean_against = ak.concatenate(            [events[x] for x in clean_against],            axis=1,        )        # load actual NanoEventArray that is to be cleaned        to_clean_field = events[to_clean]        # construct metric table for these objects. The metric table contains        # the minimal value of the metric *metric* for each object in field        # *to_clean* w.r.t. all objects in *summed_clean_against*. Thus,        # it has the dimensions nevents x nto_clean, where *nevents* is        # the number of events in the current chunk of data and *nto_clean*        # is the length of the field *to_clean*. Note that the argument        # *threshold* in the *nearest* function must be set to None since        # the function will perform a selection itself to extract the nearest        # objects (i.e. applies the selection we want here in reverse)        _, metric = to_clean_field.nearest(            summed_clean_against,            metric=metric,            return_metric=True,            threshold=None,        )        # build a binary mask based on the selection threshold provided by the        # user        mask = metric > threshold        # construct final result. Currently, this is the list of indices for        # clean jets, sorted for pt        # WARNING: this still contains the bug with the application of the mask        #           which will be adressed in a PR in the very near future        # TODO: return the mask itself instead of the list of indices        sorted_list = ak.argsort(to_clean_field.pt, axis=-1, ascending=False)[mask]        return sorted_list    return funcdelta_r_jet_lepton = cleaning_factory(    selector_name="delta_r_jet_lepton",    to_clean="Jet",    clean_against=["Muon", "Electron"],    metric=lambda a, b: a.delta_r(b),)def req_clean_delta_r_match_jet_lepton(    events: ak.Array,    to_clean: str,    clean_against: List[str],    threshold: float = 0.4,) -> List[int]:    """    do the cleaning of jets with respect to leptons.    returns indices of good (clean) jets, sorted by pt    *TODO*: this should probably changed to return the boolean masks    """    return delta_r_jet_lepton(events, to_clean, clean_against, threshold=threshold)@selector(uses={delta_r_jet_lepton})def jet_lepton_delta_r_cleaning_selection(    events: ak.Array,    stats: Dict[str, Union[int, float]],    threshold: float = 0.4,) -> SelectionResult:    """    function to apply the selection requirements necessary for a    cleaning of jets against leptons.    The function calls the requirements to clean the field *Jet* against    the concatination of the fields *[Muon, Electron]*, i.e. all leptons    and passes the desired threshold for the selection    """    clean_jet_indices = req_clean_delta_r_match_jet_lepton(events, "Jet", ["Muon", "Electron"], threshold=threshold)    return SelectionResult(        objects={"Jet": clean_jet_indices},    )@selector(uses={jet_lepton_delta_r_cleaning_selection})def jet_lepton_delta_r_cleaning(    events: ak.Array,    stats: Dict[str, Union[int, float]],    threshold: float = 0.4,    **kwargs,) -> SelectionResult:    """    Selector function that performs cleaning of jets against leptons    based on a delta_r requirement    """    results = jet_lepton_delta_r_cleaning_selection(events, stats, threshold=threshold)    return results

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -1,1 +1,493 @@
-# coding: utf-8"""Selection methods for testing purposes."""from typing import Callable, Dict, List, Optional, Unionfrom ap.selection import selector, SelectionResultfrom ap.util import maybe_importfrom ap.columnar_util import set_ak_columnak = maybe_import("awkward")np = maybe_import("numpy")def extract(array, idx):    """    inputs jagged array and index and returns padded array from given index    """    array = ak.pad_none(array, idx + 1)    array = ak.fill_none(array[:, idx], -999)    return array# object definitions# TODO: Producer instead of Selector@selector(uses={"Jet.pt", "Jet.eta"})def req_jet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]@selector(uses={"Electron.pt", "Electron.eta", "Electron.cutBased"})def req_electron(events):    mask = (events.Electron.pt > 25) & (abs(events.Electron.eta) < 2.4) & (events.Electron.cutBased == 4)    return ak.argsort(events.Electron.pt, axis=-1, ascending=False)[mask]@selector(uses={"Muon.pt", "Muon.eta", "Muon.tightId"})def req_muon(events):    mask = (events.Muon.pt > 25) & (abs(events.Muon.eta) < 2.4) & (events.Muon.tightId)    return ak.argsort(events.Muon.pt, axis=-1, ascending=False)[mask]@selector(uses={"Jet.pt", "Jet.eta"})def req_forwardJet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) > 2.4) & (abs(events.Jet.eta) < 5.0)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]@selector(uses={"Jet.pt", "Jet.eta", "Jet.btagDeepFlavB"})def req_deepjet(events):    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4) & (events.Jet.btagDeepFlavB > 0.3)    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]# variables (after reducing events)# TODO: this should maybe be a producer@selector(    uses={        "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta", "Jet.pt", "Jet.eta",        "Jet.btagDeepFlavB",    },    produces={"HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt"} | {        f"Jet{i}_{attr}"        for i in range(1, 4 + 1)        for attr in ["pt", "eta"]    },)def variables(events):    set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))    set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))    set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))    set_ak_column(events, "nMuon", ak.num(events.Muon.pt, axis=1))    set_ak_column(events, "nDeepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))    set_ak_column(events, "Electron1_pt", extract(events.Electron.pt, 0))    set_ak_column(events, "Muon1_pt", extract(events.Muon.pt, 0))    for i in range(1, 4 + 1):        set_ak_column(events, f"Jet{i}_pt", extract(events.Jet.pt, i - 1))        set_ak_column(events, f"Jet{i}_eta", extract(events.Jet.eta, i - 1))    return None, events@selector(uses={req_jet})def var_nJet(events):    return ak.num(req_jet(events), axis=1)@selector(uses={req_deepjet})def var_nDeepjet(events):    return ak.num(req_deepjet(events), axis=1)@selector(uses={req_electron})def var_nElectron(events):    return ak.num(req_electron(events), axis=1)@selector(uses={req_muon})def var_nMuon(events):    return ak.num(req_muon(events), axis=1)@selector(uses={req_jet, "Jet.pt"})def var_HT(events):    jet_pt_sorted = events.Jet.pt[req_jet(events)]    return ak.sum(jet_pt_sorted, axis=1)# selection for the main categories@selector(uses={var_nMuon, var_nElectron})def sel_1e(events):    return (var_nMuon(events) == 0) & (var_nElectron(events) == 1)@selector(uses={var_nMuon, var_nElectron})def sel_1mu(events):    return (var_nMuon(events) == 1) & (var_nElectron(events) == 0)# selection for the sub-categories@selector(uses={sel_1e, var_nDeepjet})def sel_1e_eq1b(events):    return (sel_1e(events)) & (var_nDeepjet(events) == 1)@selector(uses={sel_1e, var_nDeepjet})def sel_1e_ge2b(events):    return (sel_1e(events)) & (var_nDeepjet(events) >= 2)@selector(uses={sel_1mu, var_nDeepjet})def sel_1mu_eq1b(events):    return (sel_1mu(events)) & (var_nDeepjet(events) == 1)@selector(uses={sel_1mu, var_nDeepjet})def sel_1mu_ge2b(events):    return (sel_1mu(events)) & (var_nDeepjet(events) >= 2)@selector(uses={sel_1mu_ge2b, var_HT})def sel_1mu_ge2b_lowHT(events):    return (sel_1mu_ge2b(events)) & (var_HT(events) <= 300)@selector(uses={sel_1mu_ge2b, var_HT})def sel_1mu_ge2b_highHT(events):    return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)"""# combination of all categories, taking categories from each level into account, not only leaf categories@selector(uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b, sel_1mu_ge2b_highHT, sel_1mu_ge2b_lowHT})def categories(events, config):    cat_titles = []# ["no_cat"]    cat_array = "no_cat"    mask_int = 0    def write_cat_array(events, categories, cat_titles, cat_array):        for cat in categories:            cat_titles.append(cat.name)            mask = globals()[cat.selection](events)            cat_array = np.where(mask, cat.name, cat_array)            if not cat.is_leaf_category:                cat_titles, cat_array = write_cat_array(events, cat.categories, cat_titles, cat_array)        return cat_titles, cat_array    cat_titles, cat_array = write_cat_array(events, config.categories, cat_titles, cat_array)    # TODO checks that categories are set up properly    return SelectionResult(        #columns={"cat_titles": cat_titles, "cat_array": cat_array}        columns={"cat_array": cat_array}    )"""# combination of all leaf categories@selector(    uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b},    produces={"cat_array"},)def categories(events, config_inst):    cat_array = 0    mask_int = 0    for cat in config_inst.get_leaf_categories():        cat_sel = cat.selection        mask = globals()[cat_sel](events)        cat_array = np.where(mask, cat.id, cat_array)        mask_int = mask_int + np.where(mask, 1, 0)  # to check orthogonality of categories    if not ak.all(mask_int == 1):        if ak.any(mask_int >= 2):            print("Leaf categories are not fully orthogonal")        else:            print("Some events are without leaf category")    set_ak_column(events, "cat_array", cat_array)    return None, events@selector(uses={req_jet}, produces={"jet_high_multiplicity"})def jet_selection_test(events, stats, **kwargs):    # example cuts:    # - require at least 4 jets with pt>30, eta<2.4    # example columns:    # - high jet multiplicity region (>=6 selected jets)    jet_indices = req_jet(events)    jet_sel = ak.num(jet_indices, axis=1) >= 4    jet_high_multiplicity = ak.num(jet_indices, axis=1) >= 6    set_ak_column(events, "jet_high_multiplicity", jet_high_multiplicity)    # build and return selection results plus new columns    return (        SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices}),        events,    )@selector(uses={req_deepjet})def deepjet_selection_test(events, stats):    deepjet_indices = req_deepjet(events)    deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1    return (        SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices}),        events,    )@selector(uses={req_muon})def muon_selection_test(events, stats):    # example cuts:    # - require exactly one muon with pt>25, eta<2.4 and tight Id    muon_indices = req_muon(events)    muon_sel = ak.num(muon_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices}),        events,    )@selector(uses={req_electron})def electron_selection_test(events, stats):    # example cuts:    # - require exactly one muon with pt>25, eta<2.4 and tight Id    electron_indices = req_electron(events)    electron_sel = ak.num(electron_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices}),        events,    )@selector(uses={req_muon, req_electron})def lepton_selection_test(events, stats):    # example cuts:    # - require exactly one lepton with pt>25, eta<2.4 and tight Id    muon_indices = req_muon(events)    electron_indices = req_electron(events)    lepton_sel = ak.num(muon_indices, axis=1) + ak.num(electron_indices, axis=1) == 1    # build and return selection results    return (        SelectionResult(            steps={"Lepton": lepton_sel},            objects={"Muon": muon_indices, "Electron": electron_indices},        ),        events,    )@selector(    uses={        jet_selection_test, lepton_selection_test, deepjet_selection_test,        "LHEWeight.originalXWGTUP",    },    produces={        categories,    },)def test(events, stats, config_inst, **kwargs):    # example cuts:    # - jet_selection_test    # - lepton_selection_test    # example stats:    # - number of events before and after selection    # - sum of mc weights before and after selection    # prepare the selection results that are updated at every step    results = SelectionResult()    # jet selection    jet_results, events = jet_selection_test(events, stats)    results += jet_results    # lepton selection    lepton_results, events = lepton_selection_test(events, stats)    results += lepton_results    # deep jet selection    deepjet_results, events = deepjet_selection_test(events, stats)    results += deepjet_results    # combined event selection after all steps    event_sel = jet_results.steps.Jet & lepton_results.steps.Lepton & deepjet_results.steps.Deepjet    results.main["event"] = event_sel    # include categories into results    category_results, events = categories(events, config_inst)    results += category_results    # increment stats    events_sel = events[event_sel]    stats["n_events"] += len(events)    stats["n_events_selected"] += ak.sum(event_sel, axis=0)    stats["sum_mc_weight"] += ak.sum(events.LHEWeight.originalXWGTUP)    stats["sum_mc_weight_selected"] += ak.sum(events_sel.LHEWeight.originalXWGTUP)    return results, events# deltaR cleaningdef cleaning_factory(    selector_name: str,    to_clean: str,    clean_against: List[str],    metric: Optional[Callable] = None,) -> Callable:    """    factory to generate a function with name *selector_name* that cleans the    field *to_clean* in the NanoEventArrays agains the field(s) *clean_agains*.    First, the necessary column names to construct four-momenta for the    different object fields are constructed, i.e. pt, eta, phi and e for the    different objects.    Finally, the actual selector function is generated, which uses these    columns.    """    # default of the metric function is the delta_r function    # of the coffea LorentzVectors    if metric is None:        metric = lambda a, b: a.delta_r(b)    # compile the list of variables that are necessary for the four momenta    # this list is always the same    variables_for_lorentzvec = ["pt", "eta", "phi", "e"]    # sum up all fields aht are to be considered, i.e. the field *to_clean*    # and all fields in *clean_against*    all_fields = clean_against + [to_clean]    # construct the set of columns that is necessary for the four momenta in    # the different fields (and thus also for the current implementation of    # the cleaning itself) by looping through the fields and variables.    uses = {        f"{x}.{var}" for x in all_fields for var in variables_for_lorentzvec    }    # additionally, also load the lengths of the different fields    uses |= {f"n{x}" for x in all_fields}    # finally, construct selector function itself    @selector(uses=uses, name=selector_name)    def func(        events: ak.Array,        to_clean: str,        clean_against: List[str],        metric: Optional[Callable] = metric,        threshold: float = 0.4,    ) -> List[int]:        """        abstract function to perform a cleaning of field *to_clean* against        a (list of) field(s) *clean_against* based on an abitrary metric        *metric* (e.g. deltaR).        First concatenate all fields in *clean_against*, which thus includes        all fields that are to be used for the comparison of the metric.        Then construct the metric for all permutations of the different objects        using the coffea nearest implementation.        All objects in field *to_clean* are removed if the metric is below the        *threshold*.        """        # concatenate the fields that are to be used in the construction        # of the metric table        summed_clean_against = ak.concatenate(            [events[x] for x in clean_against],            axis=1,        )        # load actual NanoEventArray that is to be cleaned        to_clean_field = events[to_clean]        # construct metric table for these objects. The metric table contains        # the minimal value of the metric *metric* for each object in field        # *to_clean* w.r.t. all objects in *summed_clean_against*. Thus,        # it has the dimensions nevents x nto_clean, where *nevents* is        # the number of events in the current chunk of data and *nto_clean*        # is the length of the field *to_clean*. Note that the argument        # *threshold* in the *nearest* function must be set to None since        # the function will perform a selection itself to extract the nearest        # objects (i.e. applies the selection we want here in reverse)        _, metric = to_clean_field.nearest(            summed_clean_against,            metric=metric,            return_metric=True,            threshold=None,        )        # build a binary mask based on the selection threshold provided by the        # user        mask = metric > threshold        # construct final result. Currently, this is the list of indices for        # clean jets, sorted for pt        # WARNING: this still contains the bug with the application of the mask        #           which will be adressed in a PR in the very near future        # TODO: return the mask itself instead of the list of indices        sorted_list = ak.argsort(to_clean_field.pt, axis=-1, ascending=False)[mask]        return sorted_list    return funcdelta_r_jet_lepton = cleaning_factory(    selector_name="delta_r_jet_lepton",    to_clean="Jet",    clean_against=["Muon", "Electron"],    metric=lambda a, b: a.delta_r(b),)def req_clean_delta_r_match_jet_lepton(    events: ak.Array,    to_clean: str,    clean_against: List[str],    threshold: float = 0.4,) -> List[int]:    """    do the cleaning of jets with respect to leptons.    returns indices of good (clean) jets, sorted by pt    *TODO*: this should probably changed to return the boolean masks    """    return delta_r_jet_lepton(events, to_clean, clean_against, threshold=threshold)@selector(uses={delta_r_jet_lepton})def jet_lepton_delta_r_cleaning_selection(    events: ak.Array,    stats: Dict[str, Union[int, float]],    threshold: float = 0.4,) -> SelectionResult:    """    function to apply the selection requirements necessary for a    cleaning of jets against leptons.    The function calls the requirements to clean the field *Jet* against    the concatination of the fields *[Muon, Electron]*, i.e. all leptons    and passes the desired threshold for the selection    """    clean_jet_indices = req_clean_delta_r_match_jet_lepton(events, "Jet", ["Muon", "Electron"], threshold=threshold)    return SelectionResult(        objects={"Jet": clean_jet_indices},    )@selector(uses={jet_lepton_delta_r_cleaning_selection})def jet_lepton_delta_r_cleaning(    events: ak.Array,    stats: Dict[str, Union[int, float]],    threshold: float = 0.4,    **kwargs,) -> SelectionResult:    """    Selector function that performs cleaning of jets against leptons    based on a delta_r requirement    """    results = jet_lepton_delta_r_cleaning_selection(events, stats, threshold=threshold)    return results
+# coding: utf-8
+
+"""
+Selection methods for testing purposes.
+"""
+
+from typing import Callable, Dict, List, Optional, Union
+
+from ap.selection import selector, SelectionResult
+from ap.util import maybe_import
+from ap.columnar_util import set_ak_column
+
+ak = maybe_import("awkward")
+np = maybe_import("numpy")
+
+
+def extract(array, idx):
+    """
+    inputs jagged array and index and returns padded array from given index
+    """
+    array = ak.pad_none(array, idx + 1)
+    array = ak.fill_none(array[:, idx], -999)
+    return array
+
+
+# object definitions
+# TODO: Producer instead of Selector
+@selector(uses={"Jet.pt", "Jet.eta"})
+def req_jet(events):
+    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4)
+    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
+
+
+@selector(uses={"Electron.pt", "Electron.eta", "Electron.cutBased"})
+def req_electron(events):
+    mask = (events.Electron.pt > 25) & (abs(events.Electron.eta) < 2.4) & (events.Electron.cutBased == 4)
+    return ak.argsort(events.Electron.pt, axis=-1, ascending=False)[mask]
+
+
+@selector(uses={"Muon.pt", "Muon.eta", "Muon.tightId"})
+def req_muon(events):
+    mask = (events.Muon.pt > 25) & (abs(events.Muon.eta) < 2.4) & (events.Muon.tightId)
+    return ak.argsort(events.Muon.pt, axis=-1, ascending=False)[mask]
+
+
+@selector(uses={"Jet.pt", "Jet.eta"})
+def req_forwardJet(events):
+    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) > 2.4) & (abs(events.Jet.eta) < 5.0)
+    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
+
+
+@selector(uses={"Jet.pt", "Jet.eta", "Jet.btagDeepFlavB"})
+def req_deepjet(events):
+    mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4) & (events.Jet.btagDeepFlavB > 0.3)
+    return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
+
+
+# variables (after reducing events)
+# TODO: this should maybe be a producer
+@selector(
+    uses={
+        "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta", "Jet.pt", "Jet.eta",
+        "Jet.btagDeepFlavB",
+    },
+    produces={"HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt"} | {
+        f"Jet{i}_{attr}"
+        for i in range(1, 4 + 1)
+        for attr in ["pt", "eta"]
+    },
+)
+def variables(events):
+    set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))
+    set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))
+    set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))
+    set_ak_column(events, "nMuon", ak.num(events.Muon.pt, axis=1))
+    set_ak_column(events, "nDeepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))
+    set_ak_column(events, "Electron1_pt", extract(events.Electron.pt, 0))
+    set_ak_column(events, "Muon1_pt", extract(events.Muon.pt, 0))
+
+    for i in range(1, 4 + 1):
+        set_ak_column(events, f"Jet{i}_pt", extract(events.Jet.pt, i - 1))
+        set_ak_column(events, f"Jet{i}_eta", extract(events.Jet.eta, i - 1))
+
+    return None, events
+
+
+@selector(uses={req_jet})
+def var_nJet(events):
+    return ak.num(req_jet(events), axis=1)
+
+
+@selector(uses={req_deepjet})
+def var_nDeepjet(events):
+    return ak.num(req_deepjet(events), axis=1)
+
+
+@selector(uses={req_electron})
+def var_nElectron(events):
+    return ak.num(req_electron(events), axis=1)
+
+
+@selector(uses={req_muon})
+def var_nMuon(events):
+    return ak.num(req_muon(events), axis=1)
+
+
+@selector(uses={req_jet, "Jet.pt"})
+def var_HT(events):
+    jet_pt_sorted = events.Jet.pt[req_jet(events)]
+    return ak.sum(jet_pt_sorted, axis=1)
+
+
+# selection for the main categories
+@selector(uses={var_nMuon, var_nElectron})
+def sel_1e(events):
+    return (var_nMuon(events) == 0) & (var_nElectron(events) == 1)
+
+
+@selector(uses={var_nMuon, var_nElectron})
+def sel_1mu(events):
+    return (var_nMuon(events) == 1) & (var_nElectron(events) == 0)
+
+
+# selection for the sub-categories
+@selector(uses={sel_1e, var_nDeepjet})
+def sel_1e_eq1b(events):
+    return (sel_1e(events)) & (var_nDeepjet(events) == 1)
+
+
+@selector(uses={sel_1e, var_nDeepjet})
+def sel_1e_ge2b(events):
+    return (sel_1e(events)) & (var_nDeepjet(events) >= 2)
+
+
+@selector(uses={sel_1mu, var_nDeepjet})
+def sel_1mu_eq1b(events):
+    return (sel_1mu(events)) & (var_nDeepjet(events) == 1)
+
+
+@selector(uses={sel_1mu, var_nDeepjet})
+def sel_1mu_ge2b(events):
+    return (sel_1mu(events)) & (var_nDeepjet(events) >= 2)
+
+
+@selector(uses={sel_1mu_ge2b, var_HT})
+def sel_1mu_ge2b_lowHT(events):
+    return (sel_1mu_ge2b(events)) & (var_HT(events) <= 300)
+
+
+@selector(uses={sel_1mu_ge2b, var_HT})
+def sel_1mu_ge2b_highHT(events):
+    return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)
+
+
+"""
+# combination of all categories, taking categories from each level into account, not only leaf categories
+@selector(uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b, sel_1mu_ge2b_highHT, sel_1mu_ge2b_lowHT})
+def categories(events, config):
+    cat_titles = []# ["no_cat"]
+    cat_array = "no_cat"
+    mask_int = 0
+
+    def write_cat_array(events, categories, cat_titles, cat_array):
+        for cat in categories:
+            cat_titles.append(cat.name)
+            mask = globals()[cat.selection](events)
+            cat_array = np.where(mask, cat.name, cat_array)
+            if not cat.is_leaf_category:
+                cat_titles, cat_array = write_cat_array(events, cat.categories, cat_titles, cat_array)
+        return cat_titles, cat_array
+
+    cat_titles, cat_array = write_cat_array(events, config.categories, cat_titles, cat_array)
+    # TODO checks that categories are set up properly
+    return SelectionResult(
+        #columns={"cat_titles": cat_titles, "cat_array": cat_array}
+        columns={"cat_array": cat_array}
+    )
+"""
+
+
+# combination of all leaf categories
+@selector(
+    uses={sel_1e_eq1b, sel_1e_ge2b, sel_1mu_eq1b, sel_1mu_ge2b},
+    produces={"cat_array"},
+)
+def categories(events, config_inst):
+    cat_array = 0
+    mask_int = 0
+    for cat in config_inst.get_leaf_categories():
+        cat_sel = cat.selection
+        mask = globals()[cat_sel](events)
+        cat_array = np.where(mask, cat.id, cat_array)
+        mask_int = mask_int + np.where(mask, 1, 0)  # to check orthogonality of categories
+    if not ak.all(mask_int == 1):
+        if ak.any(mask_int >= 2):
+            print("Leaf categories are not fully orthogonal")
+        else:
+            print("Some events are without leaf category")
+
+    set_ak_column(events, "cat_array", cat_array)
+
+    return None, events
+
+
+@selector(uses={req_jet}, produces={"jet_high_multiplicity"})
+def jet_selection_test(events, stats, **kwargs):
+    # example cuts:
+    # - require at least 4 jets with pt>30, eta<2.4
+    # example columns:
+    # - high jet multiplicity region (>=6 selected jets)
+
+    jet_indices = req_jet(events)
+    jet_sel = ak.num(jet_indices, axis=1) >= 4
+    jet_high_multiplicity = ak.num(jet_indices, axis=1) >= 6
+
+    set_ak_column(events, "jet_high_multiplicity", jet_high_multiplicity)
+
+    # build and return selection results plus new columns
+    return (
+        SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices}),
+        events,
+    )
+
+
+@selector(uses={req_deepjet})
+def deepjet_selection_test(events, stats):
+    deepjet_indices = req_deepjet(events)
+    deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1
+
+    return (
+        SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices}),
+        events,
+    )
+
+
+@selector(uses={req_muon})
+def muon_selection_test(events, stats):
+    # example cuts:
+    # - require exactly one muon with pt>25, eta<2.4 and tight Id
+
+    muon_indices = req_muon(events)
+    muon_sel = ak.num(muon_indices, axis=1) == 1
+
+    # build and return selection results
+    return (
+        SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices}),
+        events,
+    )
+
+
+@selector(uses={req_electron})
+def electron_selection_test(events, stats):
+    # example cuts:
+    # - require exactly one muon with pt>25, eta<2.4 and tight Id
+
+    electron_indices = req_electron(events)
+    electron_sel = ak.num(electron_indices, axis=1) == 1
+
+    # build and return selection results
+    return (
+        SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices}),
+        events,
+    )
+
+
+@selector(uses={req_muon, req_electron})
+def lepton_selection_test(events, stats):
+    # example cuts:
+    # - require exactly one lepton with pt>25, eta<2.4 and tight Id
+
+    muon_indices = req_muon(events)
+    electron_indices = req_electron(events)
+    lepton_sel = ak.num(muon_indices, axis=1) + ak.num(electron_indices, axis=1) == 1
+
+    # build and return selection results
+    return (
+        SelectionResult(
+            steps={"Lepton": lepton_sel},
+            objects={"Muon": muon_indices, "Electron": electron_indices},
+        ),
+        events,
+    )
+
+
+@selector(
+    uses={
+        jet_selection_test, lepton_selection_test, deepjet_selection_test,
+        "LHEWeight.originalXWGTUP",
+    },
+    produces={
+        categories,
+    },
+)
+def test(events, stats, config_inst, **kwargs):
+    # example cuts:
+    # - jet_selection_test
+    # - lepton_selection_test
+    # example stats:
+    # - number of events before and after selection
+    # - sum of mc weights before and after selection
+
+    # prepare the selection results that are updated at every step
+    results = SelectionResult()
+
+    # jet selection
+    jet_results, events = jet_selection_test(events, stats)
+    results += jet_results
+
+    # lepton selection
+    lepton_results, events = lepton_selection_test(events, stats)
+    results += lepton_results
+
+    # deep jet selection
+    deepjet_results, events = deepjet_selection_test(events, stats)
+    results += deepjet_results
+
+    # combined event selection after all steps
+    event_sel = jet_results.steps.Jet & lepton_results.steps.Lepton & deepjet_results.steps.Deepjet
+    results.main["event"] = event_sel
+
+    # include categories into results
+    category_results, events = categories(events, config_inst)
+    results += category_results
+
+    # increment stats
+    events_sel = events[event_sel]
+    stats["n_events"] += len(events)
+    stats["n_events_selected"] += ak.sum(event_sel, axis=0)
+    stats["sum_mc_weight"] += ak.sum(events.LHEWeight.originalXWGTUP)
+    stats["sum_mc_weight_selected"] += ak.sum(events_sel.LHEWeight.originalXWGTUP)
+
+    return results, events
+
+
+# deltaR cleaning
+
+
+def cleaning_factory(
+    selector_name: str,
+    to_clean: str,
+    clean_against: List[str],
+    metric: Optional[Callable] = None,
+) -> Callable:
+    """
+    factory to generate a function with name *selector_name* that cleans the
+    field *to_clean* in the NanoEventArrays agains the field(s) *clean_agains*.
+    First, the necessary column names to construct four-momenta for the
+    different object fields are constructed, i.e. pt, eta, phi and e for the
+    different objects.
+    Finally, the actual selector function is generated, which uses these
+    columns.
+    """
+    # default of the metric function is the delta_r function
+    # of the coffea LorentzVectors
+    if metric is None:
+        metric = lambda a, b: a.delta_r(b)
+
+    # compile the list of variables that are necessary for the four momenta
+    # this list is always the same
+    variables_for_lorentzvec = ["pt", "eta", "phi", "e"]
+
+    # sum up all fields aht are to be considered, i.e. the field *to_clean*
+    # and all fields in *clean_against*
+    all_fields = clean_against + [to_clean]
+
+    # construct the set of columns that is necessary for the four momenta in
+    # the different fields (and thus also for the current implementation of
+    # the cleaning itself) by looping through the fields and variables.
+
+    uses = {
+        f"{x}.{var}" for x in all_fields for var in variables_for_lorentzvec
+    }
+
+    # additionally, also load the lengths of the different fields
+    uses |= {f"n{x}" for x in all_fields}
+
+    # finally, construct selector function itself
+    @selector(uses=uses, name=selector_name)
+    def func(
+        events: ak.Array,
+        to_clean: str,
+        clean_against: List[str],
+        metric: Optional[Callable] = metric,
+        threshold: float = 0.4,
+    ) -> List[int]:
+        """
+        abstract function to perform a cleaning of field *to_clean* against
+        a (list of) field(s) *clean_against* based on an abitrary metric
+        *metric* (e.g. deltaR).
+        First concatenate all fields in *clean_against*, which thus includes
+        all fields that are to be used for the comparison of the metric.
+        Then construct the metric for all permutations of the different objects
+        using the coffea nearest implementation.
+        All objects in field *to_clean* are removed if the metric is below the
+        *threshold*.
+        """
+
+        # concatenate the fields that are to be used in the construction
+        # of the metric table
+        summed_clean_against = ak.concatenate(
+            [events[x] for x in clean_against],
+            axis=1,
+        )
+
+        # load actual NanoEventArray that is to be cleaned
+        to_clean_field = events[to_clean]
+
+        # construct metric table for these objects. The metric table contains
+        # the minimal value of the metric *metric* for each object in field
+        # *to_clean* w.r.t. all objects in *summed_clean_against*. Thus,
+        # it has the dimensions nevents x nto_clean, where *nevents* is
+        # the number of events in the current chunk of data and *nto_clean*
+        # is the length of the field *to_clean*. Note that the argument
+        # *threshold* in the *nearest* function must be set to None since
+        # the function will perform a selection itself to extract the nearest
+        # objects (i.e. applies the selection we want here in reverse)
+        _, metric = to_clean_field.nearest(
+            summed_clean_against,
+            metric=metric,
+            return_metric=True,
+            threshold=None,
+        )
+        # build a binary mask based on the selection threshold provided by the
+        # user
+        mask = metric > threshold
+
+        # construct final result. Currently, this is the list of indices for
+        # clean jets, sorted for pt
+        # WARNING: this still contains the bug with the application of the mask
+        #           which will be adressed in a PR in the very near future
+        # TODO: return the mask itself instead of the list of indices
+        sorted_list = ak.argsort(to_clean_field.pt, axis=-1, ascending=False)[mask]
+        return sorted_list
+
+    return func
+
+
+delta_r_jet_lepton = cleaning_factory(
+    selector_name="delta_r_jet_lepton",
+    to_clean="Jet",
+    clean_against=["Muon", "Electron"],
+    metric=lambda a, b: a.delta_r(b),
+)
+
+
+def req_clean_delta_r_match_jet_lepton(
+    events: ak.Array,
+    to_clean: str,
+    clean_against: List[str],
+    threshold: float = 0.4,
+) -> List[int]:
+    """
+    do the cleaning of jets with respect to leptons.
+    returns indices of good (clean) jets, sorted by pt
+    *TODO*: this should probably changed to return the boolean masks
+    """
+    return delta_r_jet_lepton(events, to_clean, clean_against, threshold=threshold)
+
+
+@selector(uses={delta_r_jet_lepton})
+def jet_lepton_delta_r_cleaning_selection(
+    events: ak.Array,
+    stats: Dict[str, Union[int, float]],
+    threshold: float = 0.4,
+) -> SelectionResult:
+    """
+    function to apply the selection requirements necessary for a
+    cleaning of jets against leptons.
+    The function calls the requirements to clean the field *Jet* against
+    the concatination of the fields *[Muon, Electron]*, i.e. all leptons
+    and passes the desired threshold for the selection
+    """
+    clean_jet_indices = req_clean_delta_r_match_jet_lepton(events, "Jet", ["Muon", "Electron"], threshold=threshold)
+
+    return SelectionResult(
+        objects={"Jet": clean_jet_indices},
+    )
+
+
+@selector(uses={jet_lepton_delta_r_cleaning_selection})
+def jet_lepton_delta_r_cleaning(
+    events: ak.Array,
+    stats: Dict[str, Union[int, float]],
+    threshold: float = 0.4,
+    **kwargs,
+) -> SelectionResult:
+    """
+    Selector function that performs cleaning of jets against leptons
+    based on a delta_r requirement
+    """
+    results = jet_lepton_delta_r_cleaning_selection(events, stats, threshold=threshold)
+
+    return results

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -81,7 +81,9 @@ class CreateHistograms(
                 events = update_ak_array(events, *columns)
 
                 # calculate variables
-                results = variables(events)
+                # TODO: the variables callable is currently a selection function and should be a
+                #       producer soon
+                variables(events)
 
                 # weights
                 lumi = self.config_inst.x.luminosity.get("nominal")
@@ -109,11 +111,9 @@ class CreateHistograms(
                             fill_kwargs = {
                                 "category": events.cat_array,
                                 "shift": self.shift,
-                                var_name: results.columns[var_name],
+                                var_name: events[var_name],
                                 "weight": weight,
                             }
-                            print(results.columns[var_name])
-                            print(self.shift)
                             h_var.fill(**fill_kwargs)
                             if var_name in histograms:
                                 histograms[var_name] += h_var

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -31,13 +31,13 @@ class CreateHistograms(
         if not self.pilot:
             reqs["events"] = ReduceEvents.req(self)
             if self.producers:
-                reqs["columns"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+                reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
         return reqs
 
     def requires(self):
         reqs = {"events": ReduceEvents.req(self)}
         if self.producers:
-            reqs["columns"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
         return reqs
 
     def output(self):
@@ -68,7 +68,7 @@ class CreateHistograms(
         # iterate over chunks of events and diffs
         files = [inputs["events"].path]
         if self.producers:
-            files.extend([inp.path for inp in inputs["columns"]])
+            files.extend([inp.path for inp in inputs["producers"]])
         with ChunkedReader(
             files,
             source_type=len(files) * ["awkward_parquet"],

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -26,15 +26,15 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
         reqs = super().workflow_requires()
         reqs["lfns"] = GetDatasetLFNs.req(self)
         if not self.pilot:
-            reqs["calib"] = [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators]
-            reqs["sel"] = SelectEvents.req(self)
+            reqs["calibrations"] = [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators]
+            reqs["selection"] = SelectEvents.req(self)
         return reqs
 
     def requires(self):
         return {
             "lfns": GetDatasetLFNs.req(self),
-            "calib": [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators],
-            "sel": SelectEvents.req(self),
+            "calibrations": [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators],
+            "selection": SelectEvents.req(self),
         }
 
     def output(self):
@@ -77,10 +77,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
 
         # iterate over chunks of events and diffs
         input_paths = [nano_file]
-        input_paths.append(inputs["sel"]["res"].path)
-        input_paths.extend([inp.path for inp in inputs["calib"]])
+        input_paths.append(inputs["selection"]["results"].path)
+        input_paths.extend([inp.path for inp in inputs["calibrations"]])
         if self.selector_func.produced_columns:
-            input_paths.append(inputs["sel"]["cols"].path)
+            input_paths.append(inputs["selection"]["columns"].path)
         with ChunkedReader(
             input_paths,
             source_type=["coffea_root"] + (len(input_paths) - 1) * ["awkward_parquet"],

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -76,30 +76,38 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
             nano_file = input_file.load(formatter="uproot")
 
         # iterate over chunks of events and diffs
+        input_paths = [nano_file]
+        input_paths.append(inputs["sel"]["res"].path)
+        input_paths.extend([inp.path for inp in inputs["calib"]])
+        if self.selector_func.produced_columns:
+            input_paths.append(inputs["sel"]["cols"].path)
         with ChunkedReader(
-            [nano_file] + [inp.path for inp in inputs["calib"]] + [inputs["sel"]["res"].path],
-            source_type=["coffea_root", "awkward_parquet", "awkward_parquet"],
-            read_options=[{"iteritems_options": {"filter_name": load_columns_nano}}, None, None],
+            input_paths,
+            source_type=["coffea_root"] + (len(input_paths) - 1) * ["awkward_parquet"],
+            read_options=[{"iteritems_options": {"filter_name": load_columns_nano}}] + (len(input_paths) - 1) * [None],
         ) as reader:
             msg = f"iterate through {reader.n_entries} events ..."
-            for (events, *diffs, sel), pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
+            for (events, sel, *diffs), pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
                 # here, we would simply apply the mask from the selection results
                 # to filter events and objects
 
-                # add the calibrated diffs and new columns from selection results
-                events = update_ak_array(events, *(diffs + [sel.columns]))
+                # add the calibrated diffs and potentially new columns
+                events = update_ak_array(events, *diffs)
 
                 # add aliases
                 events = add_ak_aliases(events, aliases, remove_src=True)
 
                 # apply the event mask
-                events = events[sel.event]
+                event_mask = sel.event if "event" in sel.fields else Ellipsis
+                events = events[event_mask]
 
                 # apply all object masks whose names are present
+                # TODO: this should not be done automagically based on names as there might be
+                #       multiple collections of the same object type
                 for name in sel.objects.fields:
                     if name in events.fields:
                         # apply the event mask to the object mask first
-                        object_mask = sel.objects[name][sel.event]
+                        object_mask = sel.objects[name][event_mask]
                         events[name] = events[name][object_mask]
 
                 # manually remove colums that should not be kept

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -118,8 +118,17 @@ class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 # add aliases
                 events = add_ak_aliases(events, aliases)
 
-                # invoke the selection function
-                results, events = self.selector_func(events, stats, **self.get_selector_kwargs(self))
+                # invoke the selection function and parse the result which can be a single
+                # SelectionResult or a 2-tuple (SelectionResult, events)
+                obj = self.selector_func(events, stats, **self.get_selector_kwargs(self))
+                if not isinstance(obj, tuple):
+                    results = obj
+                elif len(obj) == 2:
+                    results, events = obj
+                else:
+                    raise ValueError(
+                        f"cannot interpret return value '{obj}' of selector {self.selector}",
+                    )
 
                 # save results as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")

--- a/ap/util.py
+++ b/ap/util.py
@@ -81,7 +81,7 @@ class DotDict(dict):
     def wrap(cls, d: dict) -> "DotDict":
         """
         Takes a dictionary *d* and recursively replaces it and all other nested dictionary types
-        with :py:class:`DitDict`'s for deep attribute-style access.
+        with :py:class:`DotDict`'s for deep attribute-style access.
         """
         wrap = lambda d: cls((k, wrap(v)) for k, v in d.items()) if isinstance(d, dict) else d
         return wrap(d)

--- a/ap/util.py
+++ b/ap/util.py
@@ -50,20 +50,25 @@ class DotDict(dict):
 
     .. code-block:: python
 
-       d = DotDict()
-       d["foo"] = 1
+        d = DotDict()
+        d["foo"] = 1
 
-       print(d["foo"])
-       # => 1
+        print(d["foo"])
+        # => 1
 
-       print(d.foo)
-       # => 1
+        print(d.foo)
+        # => 1
 
-       print(d["bar"])
-       # => KeyError
+        print(d["bar"])
+        # => KeyError
 
-       print(d.bar)
-       # => AttributeError
+        print(d.bar)
+        # => AttributeError
+
+        # use wrap() to convert a nested dict
+        d = DotDict({"foo": {"bar": 1}})
+        print(d.foo.bar)
+        # => 1
     """
 
     def __getattr__(self, attr):


### PR DESCRIPTION
This PR tackles the ambiguity described in #44.

>  Right now, the way that new columns can be created is somewhat two-fold. On the one hand, SelectionResult's can contain new columns that will be injected into saved selection masks. On the other hand, we have the generic producer interface that does the same but a whole lot nicer. At the same time, selector's have a produces member which is not utilized whatsover.

Changes in this PR:

- `SelectionResult` does not longer have a field for new columns.
- Selectors now can return a single `SelectionResult` or a 2-tuple (`SelectionResult`, events)
- When the selector configured for the `SelectEvents` task produces columns, `SelectEvents` will have a third output representing the produced columns (besides the selection masks and the stats file). **However**, we should only use that feature if it's really necessary (e.g. for saving columns that are required for the selection step, but are otherwise expensive to reproduce) and adhere to the `ProduceColumns` task if possible (see the task structure in #25).
- Current selectors are adapted to the above structure.

At some point, we should make some of the selectors which are actually producing sth, actual producers :)

@mafrahm