### PR TITLE
Use merged reduced events in downstream tasks

### DIFF
--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -91,7 +91,11 @@ config_2018.set_aux("category_groups", {})
 
 # variable groups for conveniently looping over certain variables
 # (used during plotting)
-config_2018.set_aux("variable_groups", {})
+config_2018.set_aux("variable_groups", {
+    "default": {
+        "HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt",
+    },
+})
 
 # shift groups for conveniently looping over certain shifts
 # (used during plotting)
@@ -168,12 +172,6 @@ config_2018.set_aux("default_producer", "variables")
 
 # event weight columns
 config_2018.set_aux("event_weights", ["normalization_weight", "pu_weight"])
-
-# file merging values
-# key -> dataset -> files per branch (-1 or not present = all)
-# TODO: maybe add selector name as additional layer
-config_2018.set_aux("file_merging", {
-})
 
 # versions per task family and optionally also dataset and shift
 # None can be used as a key to define a default value

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -526,38 +526,12 @@ class DatasetTask(ShiftTask):
         Returns the number of files that are handled in one branch. Consecutive merging steps are
         not handled yet.
         """
-        merging_info = self.config_inst.get_aux("file_merging")
         n_files = self.dataset_info_inst.n_files
 
         if isinstance(self.file_merging, int):
             # interpret the file_merging attribute as the merging factor itself
             # non-positive numbers mean "merge all in one"
             n_merge = self.file_merging if self.file_merging > 0 else n_files
-        elif self.file_merging in merging_info:
-            # file_merging refers to an entry in merging_info which can be nested as
-            # dataset -> shift -> version
-            n_merge = merging_info[self.file_merging]
-
-            # mapped to dataset?
-            if isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.dataset_inst.name, n_files)
-
-            # mapped to shift?
-            if self.shift_inst and isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.shift_inst.name, n_merge.get("nominal", n_files))
-
-            # mapped to version?
-            if self.version and isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.version, n_files)
-
-            if not isinstance(n_merge, int):
-                raise TypeError(
-                    "the merging factor in the file_merging config must be an integer, but got "
-                    f"'{n_merge}' for dataset {self.dataset_inst}, shift {self.shift_inst} and "
-                    f"version {self.version}",
-                )
-
-            n_merge = n_merge or n_files
         else:
             # no merging at all
             n_merge = 1

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -154,6 +154,8 @@ class MergeHistograms(
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # tell ForestMerge to not cache the internal merging structure by default,
+        # (this is enabled in merge_workflow_requires)
         self._cache_forest = False
 
     def create_branch_map(self):

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -32,7 +32,7 @@ class CreateHistograms(
     def workflow_requires(self):
         reqs = super(CreateHistograms, self).workflow_requires()
 
-        reqs["events"] = MergeReducedEvents.req(self)
+        reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
         if not self.pilot and self.producers:
             reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
 
@@ -163,7 +163,7 @@ class MergeHistograms(
         return law.tasks.ForestMerge.create_branch_map(self)
 
     def merge_workflow_requires(self):
-        req = CreateHistograms.req(self, _exclude=["branches"])
+        req = CreateHistograms.req(self, _exclude={"branches"})
 
         # if the merging stats exist, allow the forest to be cached
         self._cache_forest = req.merging_stats_exist

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -165,9 +165,8 @@ class MergeHistograms(
     def merge_workflow_requires(self):
         req = CreateHistograms.req(self, _exclude=["branches"])
 
-        # if the reduced merging factor is present, allow the forest to be cached
-        if req.reduced_file_merging >= 1:
-            self._cache_forest = True
+        # if the merging stats exist, allow the forest to be cached
+        self._cache_forest = req.merging_stats_exist
 
         return req
 

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -11,13 +11,13 @@ from ap.tasks.framework.mixins import (
     CalibratorsSelectorMixin, ProducersMixin, VariablesMixin, ShiftSourcesMixin,
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
-from ap.tasks.reduction import ReduceEvents
+from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from ap.tasks.production import ProduceColumns
 from ap.util import ensure_proxy, dev_sandbox
 
 
 class CreateHistograms(
-    DatasetTask,
+    MergeReducedEventsUser,
     ProducersMixin,
     CalibratorsSelectorMixin,
     VariablesMixin,
@@ -27,22 +27,24 @@ class CreateHistograms(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {ReduceEvents}
+    shifts = {MergeReducedEvents}
 
     def workflow_requires(self):
         reqs = super(CreateHistograms, self).workflow_requires()
-        if not self.pilot:
-            reqs["events"] = ReduceEvents.req(self)
-            if self.producers:
-                reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
+        reqs["events"] = MergeReducedEvents.req(self)
+        if not self.pilot and self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
         return reqs
 
     def requires(self):
-        reqs = {"events": ReduceEvents.req(self)}
+        reqs = {"events": MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"})}
         if self.producers:
             reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
         return reqs
 
+    @MergeReducedEventsUser.maybe_dummy
     def output(self):
         return self.local_target(f"histograms_vars_{self.variables_repr}_{self.branch}.pickle")
 
@@ -71,7 +73,7 @@ class CreateHistograms(
         aliases = self.shift_inst.x("column_aliases", {})
 
         # iterate over chunks of events and diffs
-        files = [inputs["events"].path]
+        files = [inputs["events"]["collection"][0].path]
         if self.producers:
             files.extend([inp.path for inp in inputs["producers"]])
         with ChunkedReader(
@@ -149,12 +151,23 @@ class MergeHistograms(
     # in each step, merge 10 into 1
     merge_factor = 10
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._cache_forest = False
+
     def create_branch_map(self):
         # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
         return law.tasks.ForestMerge.create_branch_map(self)
 
     def merge_workflow_requires(self):
-        return CreateHistograms.req(self, _exclude=["branches"])
+        req = CreateHistograms.req(self, _exclude=["branches"])
+
+        # if the reduced merging factor is present, allow the forest to be cached
+        if req.reduced_file_merging >= 1:
+            self._cache_forest = True
+
+        return req
 
     def merge_requires(self, start_leaf, end_leaf):
         return [CreateHistograms.req(self, branch=i) for i in range(start_leaf, end_leaf)]

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -30,7 +30,7 @@ class ProduceColumns(
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        reqs["events"] = MergeReducedEvents.req(self)
+        reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
         reqs["producer"] = self.producer_func.run_requires(self)
 
         return reqs

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -260,10 +260,6 @@ class MergeReducedEventsUser(DatasetTask):
         """
         Needed by DatasetTask to define the default branch map.
         """
-        return self.reduced_file_merging
-
-    @property
-    def reduced_file_merging(self):
         if self._cached_file_merging < 0:
             # reset the forest in case this is a forest ForestMerge task
             self._forest_built = False
@@ -276,6 +272,10 @@ class MergeReducedEventsUser(DatasetTask):
 
         return self._cached_file_merging
 
+    @property
+    def merging_stats_exist(self):
+        return self.file_merging >= 1
+
     def reduced_dummy_output(self):
         # dummy output to be returned in case the merging stats are not present yet
         return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
@@ -287,7 +287,7 @@ class MergeReducedEventsUser(DatasetTask):
         @functools.wraps(func)
         def wrapper(self):
             # when the merging stats do not exist yet, return a dummy target
-            if self.reduced_file_merging < 1:
+            if not self.merging_stats_exist:
                 return self.reduced_dummy_output()
 
             # otherwise, bind the wrapped function and call it

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -248,12 +248,18 @@ class MergeReducedEventsUser(DatasetTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cached value of the file_merging until it's positive and the branch map is stable
+        # cached value of the file_merging until it's positive
         self._cached_file_merging = -1
+
+        # in case this is a workflow, do not cache branches by default
+        # (this is enabled in reduced_file_merging once positive)
         self._cache_branches = False
 
     @property
     def file_merging(self):
+        """
+        Needed by DatasetTask to define the default branch map.
+        """
         return self.reduced_file_merging
 
     @property
@@ -271,10 +277,13 @@ class MergeReducedEventsUser(DatasetTask):
         return self._cached_file_merging
 
     def reduced_dummy_output(self):
+        # dummy output to be returned in case the merging stats are not present yet
         return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
 
     @classmethod
     def maybe_dummy(cls, func):
+        # meant to wrap output methods of tasks depending on merging stats
+        # to inject a dummy output in case the status are not there yet
         @functools.wraps(func)
         def wrapper(self):
             # when the merging stats do not exist yet, return a dummy target

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -4,9 +4,11 @@
 Tasks related to reducing events for use on further tasks.
 """
 
+import functools
 from collections import OrderedDict
 
 import law
+import luigi
 
 from ap.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from ap.tasks.framework.mixins import CalibratorsSelectorMixin
@@ -68,6 +70,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
         load_columns_nano = [Route.check(column).nano_column for column in load_columns]
         remove_routes = None
 
+        # event counters
+        n_all = 0
+        n_reduced = 0
+
         # let the lfn_task prepare the nano file (basically determine a good pfn)
         [(lfn_index, input_file)] = lfn_task.iter_nano_files(self)
 
@@ -98,8 +104,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 events = add_ak_aliases(events, aliases, remove_src=True)
 
                 # apply the event mask
+                n_all += len(events)
                 event_mask = sel.event if "event" in sel.fields else Ellipsis
                 events = events[event_mask]
+                n_reduced += len(events)
 
                 # apply all object masks whose names are present
                 # TODO: this should not be done automagically based on names as there might be
@@ -125,6 +133,12 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 output_chunks[pos.index] = chunk
                 reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
 
+        # some logs
+        save_div = lambda x, y: (x / y) if y else 0.0
+        self.publish_message(
+            f"reduced {n_all} to {n_reduced} events ({save_div(n_reduced, n_all) * 100:.2f}%)",
+        )
+
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
@@ -139,8 +153,14 @@ ReduceEventsWrapper = wrapper_factory(
 
 class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
 
+    n_inputs = luigi.IntParameter(
+        default=2,
+        significant=True,
+        description="minimal number of input files for sufficient statistics to infer merging "
+        "factors; default: 2",  # TODO: update once going to production
+    )
     merged_size = law.BytesParameter(
-        default=500.0,
+        default=1024.0,
         unit="MB",
         significant=False,
         description="the maximum file size of merged files; default unit is MB; default: '500MB'",
@@ -149,10 +169,10 @@ class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
     shifts = {ReduceEvents}
 
     def requires(self):
-        return ReduceEvents.req(self)
+        return ReduceEvents.req(self, branches=((0, self.n_inputs),))
 
     def output(self):
-        return self.local_target("stats.json")
+        return self.local_target(f"stats_n{self.n_inputs}.json")
 
     @law.decorator.safe_output
     def run(self):
@@ -220,28 +240,82 @@ MergeReductionStatsWrapper = wrapper_factory(
 )
 
 
-class MergeReducedEvents(DatasetTask, CalibratorsSelectorMixin, law.tasks.ForestMerge, HTCondorWorkflow):
-
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
-
-    shifts = {SelectEvents}
+class MergeReducedEventsUser(DatasetTask):
 
     # recursively merge 8 files into one
     merge_factor = 8
 
-    # the key of the config that defines the merging in the branch map of DatasetTask
-    file_merging = "after_reduction"
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # cached value of the file_merging until it's positive and the branch map is stable
+        self._cached_file_merging = -1
+        self._cache_branches = False
+
+    @property
+    def file_merging(self):
+        return self.reduced_file_merging
+
+    @property
+    def reduced_file_merging(self):
+        if self._cached_file_merging < 0:
+            # reset the forest in case this is a forest ForestMerge task
+            self._forest_built = False
+
+            # check of the merging stats is present and of so, set the cached file merging value
+            output = MergeReductionStats.req(self).output()
+            if output.exists():
+                self._cached_file_merging = output.load(formatter="json")["merge_factor"]
+                self._cache_branches = True
+
+        return self._cached_file_merging
+
+    def reduced_dummy_output(self):
+        return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
+
+    @classmethod
+    def maybe_dummy(cls, func):
+        @functools.wraps(func)
+        def wrapper(self):
+            # when the merging stats do not exist yet, return a dummy target
+            if self.reduced_file_merging < 1:
+                return self.reduced_dummy_output()
+
+            # otherwise, bind the wrapped function and call it
+            return func.__get__(self, self.__class__)()
+
+        return wrapper
+
+
+class MergeReducedEvents(MergeReducedEventsUser, CalibratorsSelectorMixin, law.tasks.ForestMerge, HTCondorWorkflow):
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+
+    shifts = {ReduceEvents, MergeReductionStats}
 
     def create_branch_map(self):
         # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
         return law.tasks.ForestMerge.create_branch_map(self)
 
     def merge_workflow_requires(self):
-        return ReduceEvents.req(self, _exclude={"branches"})
+        return {
+            "stats": MergeReductionStats.req(self),
+            "events": ReduceEvents.req(self, _exclude={"branches"}),
+        }
 
     def merge_requires(self, start_branch, end_branch):
-        return [ReduceEvents.req(self, branch=b) for b in range(start_branch, end_branch)]
+        return {
+            "stats": MergeReductionStats.req(self),
+            "events": [ReduceEvents.req(self, branch=b) for b in range(start_branch, end_branch)],
+        }
 
+    def trace_merge_workflow_inputs(self, inputs):
+        return super().trace_merge_workflow_inputs(inputs["events"])
+
+    def trace_merge_inputs(self, inputs):
+        return super().trace_merge_inputs(inputs["events"])
+
+    @MergeReducedEventsUser.maybe_dummy
     def merge_output(self):
         # use the branch_map defined in DatasetTask to compute the number of files after merging
         n_merged = len(DatasetTask.create_branch_map(self))

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -163,7 +163,7 @@ class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
         default=1024.0,
         unit="MB",
         significant=False,
-        description="the maximum file size of merged files; default unit is MB; default: '500MB'",
+        description="the maximum file size of merged files; default unit is MB; default: '1024MB'",
     )
 
     shifts = {ReduceEvents}


### PR DESCRIPTION
This PR enables the use of the `MergeReducedEvents` task so that subsequent tasks such as `ProduceColumns` and `CreateHistograms` don't need to run on tiny event files after the reduction. Instead they should require merged files which reduces job and IO overheads. The overall structure is now as suggested in #25 (graph below).

However, the `file merging factors` (== how many files to merge into one to achieve a certain file size) are very dynamic as they depend

- the dataset,
- all requested calibrators,
- the selector, and
- the shift.

The merging factors are produced and stored as a json output in `MergeReductionStats`, with all of the 4 above "parameters". Once they are known (e.g. after running a couple reduction tasks and inferring the factors), the downstream workflows are well defined in that the number of branches is known. For instance: for default calibrators and selector, the ttbar dataset is merged with a factor 15, resulting in ⌈n_lfns/15⌉ branches for downstream tasks.

The "issue" is the situation when the merging stats are not there yet. Status calls to e.g. `CreateHistograms` will not know about the number of outputs (== the number of branches). For that reason, their branch maps (and merge forests in case of `MergeHistograms`) are now essentially deferred up to the point where the merging factors are known. In the meantime, status calls will report one a single output with the basename "DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST".

Technically, this process of deferring branch maps is realized through explicitly **not** caching them (which they usually are), and allowing them to be cached once the merging stats are known.

```mermaid
graph TD
    GetDatasetLFNs(GetDatasetLFNs)
    CalibrateEvents(CalibrateEvents)
    SelectEvents(SelectEvents)
    MergeSelectionMasks(MergeSelectionMasks)
    MergeSelectionStats(MergeSelectionStats)
    ReduceEvents(ReduceEvents)
    MergeReductionStats(MergeReductionStats)
    MergeReducedEvents(MergedReducedEvents)
    ProduceColumns(ProduceColumns)
    PrepareMLEvents(PrepareMLEvents)
    MergeMLEvents(MergeMLEvents)
    MLTraining(MLTraining)
    MLEvaluation(MLEvaluation)
    CreateHistograms(CreateHistograms)
    MergeHistograms(MergeHistograms)
    MergeShiftedHistograms(MergeShiftedHistograms)
    PlotVariables(PlotVariables)
    PlotShiftedVariables(PlotShiftedVariables)
    PlotCutflow(PlotCutflow)

    classDef WF stroke: #83b, stroke-width: 3px
    classDef TODO fill: #f17925
    class CalibrateEvents WF
    class SelectEvents WF
    class ReduceEvents WF
    class MergeReducedEvents WF
    class MergeReducedEvents TODO
    class ProduceColumns WF
    class CreateHistograms WF
    class MergeHistograms WF
    class MergeShiftedHistograms WF
    class PlotVariables WF
    class PlotShiftedVariables WF
    class PrepareMLEvents TODO
    class MergeMLEvents TODO
    class MLTraining TODO
    class MLEvaluation TODO
    class MergeSelectionMasks TODO
    class PlotCutflow TODO

    GetDatasetLFNs -- lfns --> SelectEvents
    GetDatasetLFNs -- lfns --> CalibrateEvents
    CalibrateEvents -. cols .-> SelectEvents
    SelectEvents == stats ==> MergeSelectionStats
    SelectEvents == masks ==> MergeSelectionMasks
    MergeSelectionMasks -- masks --> PlotCutflow
    SelectEvents -- masks --> ReduceEvents
    SelectEvents -- cols --> ReduceEvents
    GetDatasetLFNs --lfns--> ReduceEvents
    CalibrateEvents -. cols .-> ReduceEvents
    ReduceEvents == sizes ==> MergeReductionStats
    MergeReductionStats -- factors --> MergeReducedEvents
    ReduceEvents == events ==> MergeReducedEvents
    MergeReducedEvents -- events --> CreateHistograms
    MergeReducedEvents -- events --> ProduceColumns
    MergeReducedEvents -- events --> PrepareMLEvents
    ProduceColumns -. cols .-> CreateHistograms
    ProduceColumns -. cols .-> PrepareMLEvents
    PrepareMLEvents == train/test ==> MergeMLEvents
    MergeMLEvents -- train/test --> MLTraining
    MLTraining -- model --> MLEvaluation
    PrepareMLEvents -- eval --> MLEvaluation
    MLEvaluation -- cols --> CreateHistograms
    CreateHistograms == hists ==> MergeHistograms
    MergeHistograms -- hist --> PlotVariables
    MergeHistograms == hists ==> MergeShiftedHistograms
    MergeShiftedHistograms -- hist --> PlotShiftedVariables

    subgraph Merging
        MergeSelectionStats
        MergeSelectionMasks
        MergeReductionStats
        MergeReducedEvents
    end

    subgraph Plots
        PlotCutflow
        PlotVariables
        PlotShiftedVariables
    end

    subgraph Legend
        Task(Task) --> Workflow(Workflow)
        Workflow(Workflow) --> TODO(TODO)
        class TODO TODO
        class Workflow WF
        
        X1(X) -- one<br />dep. ---> Y1(Y)
        X2(X) -. many<br />deps. ..-> Y2(Y)
        X3(X) == merges<br />many ===> Y3(Y)
    end
```

