### PR TITLE
Refine handling of variables

### DIFF
--- a/ap/columnar_util.py
+++ b/ap/columnar_util.py
@@ -5,7 +5,7 @@ Helpers and utilities for working with columnar libraries.
 """
 
 __all__ = [
-    "mandatory_coffea_columns",
+    "mandatory_coffea_columns", "EMPTY_INT", "EMPTY_FLOAT",
     "Route", "ArrayFunction", "TaskArrayFunction", "ChunkedReader", "PreloadedNanoEventsFactory",
     "get_ak_routes", "has_ak_column", "set_ak_column", "remove_ak_column", "add_ak_alias",
     "add_ak_aliases", "update_ak_array", "flatten_ak_array", "sort_ak_fields",
@@ -40,8 +40,11 @@ pq = maybe_import("pyarrow.parquet")
 #: Columns that are always required when opening a nano file with coffea.
 mandatory_coffea_columns = {"run", "luminosityBlock", "event"}
 
-#: Empty-value definition in places where a number is expected.
-EMPTY = -99999
+#: Empty-value definition in places where an integer number is expected but not present.
+EMPTY_INT = -99999
+
+#: Empty-value definition in places where a float number is expected but not present.
+EMPTY_FLOAT = -99999.0
 
 
 class Route(object):

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -12,6 +12,8 @@ from order import Analysis, Shift
 
 import ap.config.processes as procs
 from ap.config.campaign_2018 import campaign_2018
+from ap.config.categories import add_categories
+from ap.config.variables import add_variables
 from ap.util import DotDict
 
 
@@ -44,6 +46,63 @@ analysis_st.set_aux("config_groups", {})
 
 # create a config by passing the campaign, so id and name will be identical
 config_2018 = analysis_st.add_config(campaign_2018)
+
+# add processes we are interested in
+config_2018.add_process(procs.process_data)
+config_2018.add_process(procs.process_st)
+config_2018.add_process(procs.process_tt)
+
+# add datasets we need to study
+dataset_names = [
+    "data_mu_a",
+    "st_tchannel_t",
+    "st_tchannel_tbar",
+    "st_twchannel_t",
+    "st_twchannel_tbar",
+    "tt_sl",
+    "tt_dl",
+    "tt_fh",
+]
+for dataset_name in dataset_names:
+    config_2018.add_dataset(campaign_2018.get_dataset(dataset_name))
+
+
+# process groups for conveniently looping over certain processs
+# (used in wrapper_factory and during plotting)
+config_2018.set_aux("process_groups", {})
+
+# dataset groups for conveniently looping over certain datasets
+# (used in wrapper_factory and during plotting)
+config_2018.set_aux("dataset_groups", {})
+
+# category groups for conveniently looping over certain categories
+# (used during plotting)
+config_2018.set_aux("category_groups", {})
+
+# variable groups for conveniently looping over certain variables
+# (used during plotting)
+config_2018.set_aux("variable_groups", {})
+
+# shift groups for conveniently looping over certain shifts
+# (used during plotting)
+config_2018.set_aux("shift_groups", {})
+
+# default calibrator, selector and producer
+config_2018.set_aux("default_calibrator", "test")
+config_2018.set_aux("default_selector", "test")
+config_2018.set_aux("default_producer", "variables")
+
+# 2018 luminosity with values in inverse pb and uncertainties taken from
+# https://twiki.cern.ch/twiki/bin/view/CMS/TWikiLUM?rev=171#LumiComb
+config_2018.set_aux("luminosity", Number(59740, {
+    "lumi_13TeV_correlated": (REL, 0.02),
+    "lumi_13TeV_2018": (REL, 0.015),
+    "lumi_13TeV_1718": (REL, 0.002),
+}))
+
+# 2018 minimum bias cross section in mb (milli) for creating PU weights, values from
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/PileupJSONFileforData?rev=44#Pileup_JSON_Files_For_Run_II
+config_2018.set_aux("minbiasxs", Number(69.2, (REL, 0.046)))
 
 # location of JEC txt files
 config_2018.set_aux("jec", DotDict.wrap({
@@ -122,75 +181,6 @@ config_2018.set_aux("jer", DotDict.wrap({
 }))
 
 
-def make_jme_filenames(jme_aux, sample_type, names, era=None):
-    """Convenience function to compute paths to JEC files."""
-
-    # normalize and validate sample type
-    sample_type = sample_type.upper()
-    if sample_type not in ("DATA", "MC"):
-        raise ValueError(f"Invalid sample type '{sample_type}'. Expected either 'DATA' or 'MC'.")
-
-    jme_full_version = "_".join(s for s in (jme_aux.campaign, era, jme_aux.version, sample_type) if s)
-
-    return [
-        f"{jme_aux.source}/{jme_full_version}/{jme_full_version}_{name}_{jme_aux.jet_type}.txt"
-        for name in names
-    ]
-
-
-# 2018 luminosity with values in inverse pb and uncertainties taken from
-# https://twiki.cern.ch/twiki/bin/view/CMS/TWikiLUM?rev=171#LumiComb
-config_2018.set_aux("luminosity", Number(59740, {
-    "lumi_13TeV_correlated": (REL, 0.02),
-    "lumi_13TeV_2018": (REL, 0.015),
-    "lumi_13TeV_1718": (REL, 0.002),
-}))
-
-# 2018 minimum bias cross section in mb (milli) for creating PU weights, values from
-# https://twiki.cern.ch/twiki/bin/viewauth/CMS/PileupJSONFileforData?rev=44#Pileup_JSON_Files_For_Run_II
-config_2018.set_aux("minbiasxs", Number(69.2, (REL, 0.046)))
-
-# add processes we are interested in
-config_2018.add_process(procs.process_data)
-config_2018.add_process(procs.process_st)
-config_2018.add_process(procs.process_tt)
-
-# add datasets we need to study
-dataset_names = [
-    "data_mu_a",
-    "st_tchannel_t",
-    "st_tchannel_tbar",
-    "st_twchannel_t",
-    "st_twchannel_tbar",
-    "tt_sl",
-    "tt_dl",
-    "tt_fh",
-]
-for dataset_name in dataset_names:
-    config_2018.add_dataset(campaign_2018.get_dataset(dataset_name))
-
-
-# process groups for conveniently looping over certain processs
-# (used in wrapper_factory and during plotting)
-config_2018.set_aux("process_groups", {})
-
-# dataset groups for conveniently looping over certain datasets
-# (used in wrapper_factory and during plotting)
-config_2018.set_aux("dataset_groups", {})
-
-# category groups for conveniently looping over certain categories
-# (used during plotting)
-config_2018.set_aux("category_groups", {})
-
-# variable groups for conveniently looping over certain variables
-# (used during plotting)
-config_2018.set_aux("variable_groups", {})
-
-# shift groups for conveniently looping over certain shifts
-# (used during plotting)
-config_2018.set_aux("shift_groups", {})
-
-
 # helper to add column aliases for both shifts of a source
 def add_aliases(shift_source, aliases):
     for direction in ["up", "down"]:
@@ -225,6 +215,23 @@ add_aliases("minbias_xs", {"pu_weight": "pu_weight_{name}"})
 config_2018.add_shift(name="top_pt_up", id=9, type="shape")
 config_2018.add_shift(name="top_pt_down", id=10, type="shape")
 add_aliases("top_pt", {"top_pt_weight": "top_pt_weight_{direction}"})
+
+
+def make_jme_filenames(jme_aux, sample_type, names, era=None):
+    """Convenience function to compute paths to JEC files."""
+
+    # normalize and validate sample type
+    sample_type = sample_type.upper()
+    if sample_type not in ("DATA", "MC"):
+        raise ValueError(f"Invalid sample type '{sample_type}'. Expected either 'DATA' or 'MC'.")
+
+    jme_full_version = "_".join(s for s in (jme_aux.campaign, era, jme_aux.version, sample_type) if s)
+
+    return [
+        f"{jme_aux.source}/{jme_full_version}/{jme_full_version}_{name}_{jme_aux.jet_type}.txt"
+        for name in names
+    ]
+
 
 # external files
 config_2018.set_aux("external_files", DotDict.wrap({
@@ -297,11 +304,6 @@ config_2018.set_aux("keep_columns", DotDict.wrap({
     },
 }))
 
-# default calibrator, selector and producer
-config_2018.set_aux("default_calibrator", "test")
-config_2018.set_aux("default_selector", "test")
-config_2018.set_aux("default_producer", "variables")
-
 # event weight columns
 config_2018.set_aux("event_weights", ["normalization_weight", "pu_weight"])
 
@@ -316,128 +318,8 @@ config_2018.set_aux("file_merging", {
 config_2018.set_aux("versions", {
 })
 
-# define categories
-# TODO: move their definition to dedicated file
-cat_e = config_2018.add_category(
-    name="1e",
-    id=1,
-    label="1 electron",
-    selection="sel_1e",
-)
-cat_mu = config_2018.add_category(
-    name="1mu",
-    id=2,
-    label="1 muon",
-    selection="sel_1mu",
-)
+# add categories
+add_categories(config_2018)
 
-cat_e_b = cat_e.add_category(
-    name="1e_eq1b",
-    id=3,
-    label="1e, 1 b-tag",
-    selection="sel_1e_eq1b",
-)
-cat_e_bb = cat_e.add_category(
-    name="1e_ge2b",
-    id=4,
-    label=r"1e, $\geq$ 2 b-tags",
-    selection="sel_1e_ge2b",
-)
-cat_mu_b = cat_mu.add_category(
-    name="1mu_eq1b",
-    id=5,
-    label="1mu, 1 b-tag",
-    selection="sel_1mu_eq1b",
-)
-cat_mu_bb = cat_mu.add_category(
-    name="1mu_ge2b",
-    id=6,
-    label=r"1mu, $\geq$ 2 b-tags",
-    selection="sel_1mu_ge2b",
-)
-cat_mu_bb_lowHT = cat_mu_bb.add_category(
-    name="1mu_ge2b_lowHT",
-    id=7,
-    label=r"1mu, $\geq$ 2 b-tags, HT<=300 GeV",
-    selection="sel_1mu_ge2b_lowHT",
-)
-cat_mu_bb_highHT = cat_mu_bb.add_category(
-    name="1mu_ge2b_highHT",
-    id=8,
-    label=r"1mu, $\geq$ 2 b-tags, HT>300 GeV",
-    selection="sel_1mu_ge2b_highHT",
-)
-
-# define variables
-# TODO: move their definition to dedicated file
-config_2018.add_variable(
-    name="HT",
-    binning=[0, 80, 120, 160, 200, 240, 280, 320, 400, 500, 600, 800],
-    unit="GeV",
-    x_title="HT",
-)
-config_2018.add_variable(
-    name="nElectron",
-    binning=(6, -0.5, 5.5),
-    x_title="Number of electrons",
-)
-config_2018.add_variable(
-    name="nMuon",
-    binning=(6, -0.5, 5.5),
-    x_title="Number of muons",
-)
-config_2018.add_variable(
-    name="Electron1_pt",
-    binning=(40, 0., 400.),
-    unit="GeV",
-    x_title="Leading electron $p_{T}$",
-)
-config_2018.add_variable(
-    name="Muon1_pt",
-    binning=(40, 0., 400.),
-    unit="GeV",
-    x_title="Leading muon $p_{T}$",
-)
-config_2018.add_variable(
-    name="nJet",
-    binning=(11, -0.5, 10.5),
-    x_title="Number of jets",
-)
-config_2018.add_variable(
-    name="nDeepjet",
-    binning=(8, -0.5, 7.5),
-    x_title="Number of deepjets",
-)
-config_2018.add_variable(
-    name="Jet1_pt",
-    binning=(40, 0., 400.),
-    unit="GeV",
-    x_title="Leading jet $p_{T}$",
-)
-config_2018.add_variable(
-    name="Jet2_pt",
-    binning=(40, 0., 400.),
-    unit="GeV",
-    x_title="Jet 2 $p_{T}$",
-)
-config_2018.add_variable(
-    name="Jet3_pt",
-    binning=(40, 0., 400.),
-    unit="GeV",
-    x_title="Jet 3 $p_{T}$",
-)
-config_2018.add_variable(
-    name="Jet1_eta",
-    binning=(50, -2.5, 2.5),
-    x_title=r"Leading jet $\eta$",
-)
-config_2018.add_variable(
-    name="Jet2_eta",
-    binning=(50, -2.5, 2.5),
-    x_title=r"Jet 2 $\eta$",
-)
-config_2018.add_variable(
-    name="Jet3_eta",
-    binning=(50, -2.5, 2.5),
-    x_title=r"Jet 3 $\eta$",
-)
+# add variables
+add_variables(config_2018)

--- a/ap/config/categories.py
+++ b/ap/config/categories.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+
+"""
+Definition of categories.
+"""
+
+import order as od
+
+
+def add_categories(config: od.Config) -> None:
+    """
+    Adds all categories to a *config*.
+    """
+    cat_e = config.add_category(
+        name="1e",
+        id=1,
+        label="1 electron",
+        selection="sel_1e",
+    )
+    cat_mu = config.add_category(
+        name="1mu",
+        id=2,
+        label="1 muon",
+        selection="sel_1mu",
+    )
+    cat_e.add_category(
+        name="1e_eq1b",
+        id=3,
+        label="1e, 1 b-tag",
+        selection="sel_1e_eq1b",
+    )
+    cat_e.add_category(
+        name="1e_ge2b",
+        id=4,
+        label=r"1e, $\geq$ 2 b-tags",
+        selection="sel_1e_ge2b",
+    )
+    cat_mu.add_category(
+        name="1mu_eq1b",
+        id=5,
+        label="1mu, 1 b-tag",
+        selection="sel_1mu_eq1b",
+    )
+    cat_mu_bb = cat_mu.add_category(
+        name="1mu_ge2b",
+        id=6,
+        label=r"1mu, $\geq$ 2 b-tags",
+        selection="sel_1mu_ge2b",
+    )
+    cat_mu_bb.add_category(
+        name="1mu_ge2b_lowHT",
+        id=7,
+        label=r"1mu, $\geq$ 2 b-tags, HT<=300 GeV",
+        selection="sel_1mu_ge2b_lowHT",
+    )
+    cat_mu_bb.add_category(
+        name="1mu_ge2b_highHT",
+        id=8,
+        label=r"1mu, $\geq$ 2 b-tags, HT>300 GeV",
+        selection="sel_1mu_ge2b_highHT",
+    )

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+
+"""
+Definition of variables.
+"""
+
+import order as od
+
+from ap.columnar_util import EMPTY_FLOAT
+
+
+def add_variables(config: od.Config) -> None:
+    """
+    Adds all variables to a *config*.
+    """
+    config.add_variable(
+        name="ht",
+        binning=[0, 80, 120, 160, 200, 240, 280, 320, 400, 500, 600, 800],
+        unit="GeV",
+        x_title="HT",
+    )
+    config.add_variable(
+        name="n_electron",
+        binning=(6, -0.5, 5.5),
+        x_title="Number of electrons",
+    )
+    config.add_variable(
+        name="n_muon",
+        binning=(6, -0.5, 5.5),
+        x_title="Number of muons",
+    )
+    config.add_variable(
+        name="electron1_pt",
+        expression="Electron.pt.0",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Electron 1 $p_{T}$",
+    )
+    config.add_variable(
+        name="muon1_pt",
+        expression="Muon.pt.0",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Muon 1 $p_{T}$",
+    )
+    config.add_variable(
+        name="n_jet",
+        binning=(11, -0.5, 10.5),
+        x_title="Number of jets",
+    )
+    config.add_variable(
+        name="n_deepjet",
+        binning=(8, -0.5, 7.5),
+        x_title="Number of deepjets",
+    )
+    config.add_variable(
+        name="jet1_pt",
+        expression="Jet.pt.0",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Jet 1 $p_{T}$",
+    )
+    config.add_variable(
+        name="jet2_pt",
+        expression="Jet.pt.1",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Jet 2 $p_{T}$",
+    )
+    config.add_variable(
+        name="jet3_pt",
+        expression="Jet.pt.2",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Jet 3 $p_{T}$",
+    )
+    config.add_variable(
+        name="jet1_eta",
+        expression="Jet.eta.0",
+        null_value=EMPTY_FLOAT,
+        binning=(50, -2.5, 2.5),
+        x_title=r"Jet 1 $\eta$",
+    )
+    config.add_variable(
+        name="jet2_eta",
+        expression="Jet.eta.1",
+        null_value=EMPTY_FLOAT,
+        binning=(50, -2.5, 2.5),
+        x_title=r"Jet 2 $\eta$",
+    )
+    config.add_variable(
+        name="jet3_eta",
+        expression="Jet.eta.2",
+        null_value=EMPTY_FLOAT,
+        binning=(50, -2.5, 2.5),
+        x_title=r"Jet 3 $\eta$",
+    )

--- a/ap/production/features.py
+++ b/ap/production/features.py
@@ -7,20 +7,11 @@ Column production methods related to higher-level features.
 from ap.production import producer
 from ap.production.weights import event_weights
 from ap.util import maybe_import
-from ap.columnar_util import EMPTY, set_ak_column, has_ak_column
+from ap.columnar_util import set_ak_column, has_ak_column
 
 from ap.selection.test import jet_energy_shifts
 
 ak = maybe_import("awkward")
-
-
-def extract(ak_array: ak.Array, idx: int) -> ak.Array:
-    """
-    Takes an jagged *ak_array* and an index and returns padded array from given index.
-    """
-    ak_array = ak.pad_none(ak_array, idx + 1)
-    ak_array = ak.fill_none(ak_array[:, idx], EMPTY)
-    return ak_array
 
 
 @producer(
@@ -31,29 +22,19 @@ def extract(ak_array: ak.Array, idx: int) -> ak.Array:
     },
     produces={
         event_weights,
-        "HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt",
-    } | {
-        f"Jet{i}_{attr}"
-        for i in range(1, 4 + 1)
-        for attr in ["pt", "eta"]
+        "ht", "n_jet", "n_electron", "n_muon", "n_deepjet",
     },
     shifts={jet_energy_shifts},
 )
 def variables(events: ak.Array, **kwargs) -> ak.Array:
-    if has_ak_column(events, "HT"):
+    if has_ak_column(events, "ht"):
         return events
 
-    set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))
-    set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))
-    set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))
-    set_ak_column(events, "nMuon", ak.num(events.Muon.pt, axis=1))
-    set_ak_column(events, "nDeepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))
-    set_ak_column(events, "Electron1_pt", extract(events.Electron.pt, 0))
-    set_ak_column(events, "Muon1_pt", extract(events.Muon.pt, 0))
-
-    for i in range(1, 4 + 1):
-        set_ak_column(events, f"Jet{i}_pt", extract(events.Jet.pt, i - 1))
-        set_ak_column(events, f"Jet{i}_eta", extract(events.Jet.eta, i - 1))
+    set_ak_column(events, "ht", ak.sum(events.Jet.pt, axis=1))
+    set_ak_column(events, "n_jet", ak.num(events.Jet.pt, axis=1))
+    set_ak_column(events, "n_electron", ak.num(events.Electron.pt, axis=1))
+    set_ak_column(events, "n_muon", ak.num(events.Muon.pt, axis=1))
+    set_ak_column(events, "n_deepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))
 
     # add event weights
     event_weights(events, **kwargs)

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -4,6 +4,8 @@
 Task to produce and merge histograms.
 """
 
+import re
+
 import law
 
 from ap.tasks.framework.base import DatasetTask
@@ -103,6 +105,29 @@ class CreateHistograms(
                 # define and fill histograms
                 for var_name in self.variables:
                     variable_inst = self.config_inst.get_variable(var_name)
+
+                    # get the expression and when it's a string, parse it to extract trailing index
+                    # lookups, e.g. "Jet.pt.0", and convert them to functions with optional padding
+                    expr = variable_inst.expression
+                    if isinstance(expr, str):
+                        fields = Route.check(expr).fields
+                        # first, assume a normal route
+                        expr = lambda events: events[fields]
+                        # when the last field is an integer, perform filling and padding with the
+                        # variable's null value
+                        if len(fields) > 1 and re.match(r"^\d+$", fields[-1]):
+                            if variable_inst.null_value is None:
+                                raise ValueError(
+                                    "variable expressions with a trailing index require a "
+                                    f"null_value, but '{variable_inst}' has none",
+                                )
+                            idx = int(fields[-1])
+                            def expr(events):
+                                return ak.fill_none(
+                                    ak.pad_none(events[fields[:-1]], idx + 1, axis=-1)[..., idx],
+                                    variable_inst.null_value,
+                                )
+
                     with self.publish_step("var: %s" % var_name):
                         h_var = (
                             hist.Hist.new
@@ -117,7 +142,7 @@ class CreateHistograms(
                             .Weight()
                         )
                         fill_kwargs = {
-                            var_name: events[Route.check(variable_inst.expression).fields],
+                            var_name: expr(events),
                             "process": events.process_id,
                             "category": events.cat_array,
                             "shift": self.shift,


### PR DESCRIPTION
This PR is rather short and implements two things:

1. Variables and categories are now defined in separate files in the `ap.config` directory.
2. Variable expressions can be routes such as `Jet.pt.0`, which is understood by the `CreateHistograms` task which does automatic padding & filling with the variable's `null_value` in case the trailing index exceeds the length of the ragged axis (as was done by the 'extract' helper function).

FYI: there are a couple changes in the `analysis_st.py` main config, but I only rearranged some blocks.