### PR TITLE
[WIP] ML Workflow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ Analysis playground
    :target: https://github.com/uhh-cms/analysis_playground/actions/workflows/lint_and_test.yaml
    :alt: Build status
 
+.. image:: https://codecov.io/gh/uhh-cms/analysis_playground/branch/dev/graph/badge.svg?token=33FLINPXFP
+   :target: https://codecov.io/gh/uhh-cms/analysis_playground
+   :alt: Code coverge
+
 .. image:: https://readthedocs.org/projects/analysis_playground/badge
    :target: http://analysis_playground.readthedocs.io
    :alt: Documentation status
@@ -12,10 +16,6 @@ Analysis playground
 .. image:: https://img.shields.io/github/license/uhh-cms/analysis_playground.svg
    :target: https://github.com/uhh-cms/analysis_playground/blob/master/LICENSE
    :alt: License
-
-.. image:: https://codecov.io/gh/uhh-cms/analysis_playground/branch/dev/graph/badge.svg?token=MePbStZF7U
-   :target: https://codecov.io/gh/uhh-cms/analysis_playground
-   :alt: Code coverge
 
 Demonstrator for a Python-based, vectorized analysis with a bunch of public HEP tools.
 

--- a/ap/__init__.py
+++ b/ap/__init__.py
@@ -53,6 +53,11 @@ if law.config.has_option("analysis", "selection_modules"):
         logger.debug(f"loading selection module '{mod}'")
         maybe_import(mod.strip())
 
+if law.config.has_option("analysis", "ml_modules"):
+    for mod in law.config.get_expanded("analysis", "ml_modules", split_csv=True):
+        logger.debug(f"loading ml module '{mod}'")
+        maybe_import(mod.strip())
+
 # preload all task modules so that task parameters are globally known and accepted
 if law.config.has_section("modules"):
     for mod in law.config.options("modules"):

--- a/ap/calibration/jets.py
+++ b/ap/calibration/jets.py
@@ -130,7 +130,7 @@ def ak_random(*args, rand_func):
         "Jet.pt", "Jet.mass", "Jet.rawFactor",
     },
 )
-def jec(events, config_inst, dataset_inst, jec_files, junc_files, jec_names, junc_names, **kwargs):
+def jec(self, events, config_inst, dataset_inst, jec_files, junc_files, jec_names, junc_names, **kwargs):
     """Apply jet energy corrections and calculate shifts for jet energy uncertainty sources."""
 
     # calculate uncorrected pt, mass
@@ -265,7 +265,7 @@ def jec_setup(self, task, inputs, call_kwargs, **kwargs):
 
     },
 )
-def jer(events, config_inst, dataset_inst, jer_files, jersf_files, jer_names, jersf_names, **kwargs):
+def jer(self, events, config_inst, dataset_inst, jer_files, jersf_files, jer_names, jersf_names, **kwargs):
     """Apply jet energy resolution smearing and calculate shifts for JER scale factor variations.
     Follows the recommendations given in https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution."""
 
@@ -417,7 +417,7 @@ def jer_setup(self, task, inputs, call_kwargs, **kwargs):
 #
 
 @calibrator(uses={jec}, produces={jec})
-def jets(events, **kwargs):
+def jets(self, events, **kwargs):
     # apply jet energy corrections
     events = jec(events, **kwargs)
 

--- a/ap/calibration/seeds.py
+++ b/ap/calibration/seeds.py
@@ -11,7 +11,7 @@ import law
 
 from ap.calibration import calibrator
 from ap.util import maybe_import, primes
-from ap.columnar_util import Route, set_ak_column, has_ak_column
+from ap.columnar_util import Route, set_ak_column
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -110,9 +110,8 @@ def deterministic_jet_seeds(
     setup function is used to access the *create_seed* function. The strategy for producing seeds is
     identical.
     """
-    # create the event seeds if not already present
-    if not has_ak_column(events, "deterministic_seed"):
-        events = deterministic_event_seeds(events, create_seed=create_seed, **kwargs)
+    # create the event seeds
+    deterministic_event_seeds(events, create_seed=create_seed, **kwargs)
 
     # create the per jet seeds
     prime_offset = 18
@@ -147,9 +146,9 @@ def deterministic_seeds(
     :py:func:`deterministic_jet_seeds`.
     """
     # create the event seeds
-    events = deterministic_event_seeds(events, **kwargs)
+    deterministic_event_seeds(events, **kwargs)
 
     # create the jet seeds
-    events = deterministic_jet_seeds(events, **kwargs)
+    deterministic_jet_seeds(events, **kwargs)
 
     return events

--- a/ap/calibration/test.py
+++ b/ap/calibration/test.py
@@ -7,6 +7,7 @@ Calibration methods for testing purposes.
 from ap.calibration import calibrator
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
+from ap.production.seeds import deterministic_seeds
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -42,8 +43,9 @@ def jec_test(events, **kwargs):
     return events
 
 
-@calibrator(uses={jec_test}, produces={jec_test})
-def test(events, **kwargs):
+@calibrator(uses={jec_test, deterministic_seeds}, produces={jec_test, deterministic_seeds})
+def test(self, events, **kwargs):
     jec_test(events, **kwargs)
+    deterministic_seeds(events, **kwargs)
 
     return events

--- a/ap/calibration/test.py
+++ b/ap/calibration/test.py
@@ -14,14 +14,16 @@ ak = maybe_import("awkward")
 
 
 @calibrator(
-    uses={"nJet", "Jet.pt", "Jet.mass"},
+    uses={
+        "nJet", "Jet.pt", "Jet.mass",
+    },
     produces={
         "Jet.pt", "Jet.mass",
         "Jet.pt_jec_up", "Jet.mass_jec_up",
         "Jet.pt_jec_down", "Jet.mass_jec_down",
     },
 )
-def jec_test(events, **kwargs):
+def jec_test(self, events, **kwargs):
     # a) "correct" Jet.pt by scaling four momenta by 1.1 (pt<30) or 0.9 (pt<=30)
     # b) add 4 new columns representing the effect of JEC variations
 

--- a/ap/calibration/test.py
+++ b/ap/calibration/test.py
@@ -44,6 +44,6 @@ def jec_test(events, **kwargs):
 
 @calibrator(uses={jec_test}, produces={jec_test})
 def test(events, **kwargs):
-    events = jec_test(events, **kwargs)
+    jec_test(events, **kwargs)
 
     return events

--- a/ap/columnar_util.py
+++ b/ap/columnar_util.py
@@ -21,7 +21,7 @@ import weakref
 import multiprocessing
 import multiprocessing.pool
 from functools import partial
-from collections import namedtuple, OrderedDict
+from collections import namedtuple, OrderedDict, defaultdict
 from typing import Optional, Union, Sequence, Set, Tuple, List, Dict, Callable, Any
 
 import law
@@ -1129,11 +1129,32 @@ class TaskArrayFunction(ArrayFunction):
         # store the call kwargs
         self.call_kwargs = call_kwargs
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, call_cache=None, call_force=False, **kwargs):
         """
         Calls the wrapped function with all *args* and *kwargs*. The latter is updated with
         :py:attr:`call_kwargs` when set, but giving priority to existing *kwargs*.
+
+        Also, all calls are cached unless *call_cache* is *False*. In case caching is active and
+        this instance was called before (identified by its class and :py:attr:`name`), it is not
+        called again but *None* is returned. This check can be bypassed for this call only by
+        setting *call_force* to *True*.
         """
+        # call caching
+        cache_kwargs = {}
+        if call_cache is False:
+            # setup a new call cache when not present yet
+            if call_cache is None:
+                call_cache = defaultdict(int)
+
+            # check if the instance was called before
+            cache_key = (self.__class__, self.__name__)
+            if call_cache[cache_key] > 0 and not call_force:
+                return
+
+            # increase the count and set kwargs for the call downstream
+            call_cache[cache_key] += 1
+            cache_kwargs["call_cache"] = call_cache
+
         if self.call_kwargs:
             kwargs = law.util.merge_dicts(self.call_kwargs, kwargs)
 

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -87,10 +87,11 @@ config_2018.set_aux("variable_groups", {})
 # (used during plotting)
 config_2018.set_aux("shift_groups", {})
 
-# default calibrator, selector and producer
+# default calibrator, selector, producer and ml_model
 config_2018.set_aux("default_calibrator", "test")
 config_2018.set_aux("default_selector", "test")
 config_2018.set_aux("default_producer", "variables")
+config_2018.set_aux("default_ml_model", "test")
 
 # 2018 luminosity with values in inverse pb and uncertainties taken from
 # https://twiki.cern.ch/twiki/bin/view/CMS/TWikiLUM?rev=171#LumiComb
@@ -194,10 +195,10 @@ def add_aliases(shift_source, aliases):
 
 # register shifts
 config_2018.add_shift(name="nominal", id=0)
-config_2018.add_shift(name="tune_up", id=1, type="shape")
-config_2018.add_shift(name="tune_down", id=2, type="shape")
-config_2018.add_shift(name="hdamp_up", id=3, type="shape")
-config_2018.add_shift(name="hdamp_down", id=4, type="shape")
+config_2018.add_shift(name="tune_up", id=1, type="shape", aux={"disjoint": True})
+config_2018.add_shift(name="tune_down", id=2, type="shape", aux={"disjoint": True})
+config_2018.add_shift(name="hdamp_up", id=3, type="shape", aux={"disjoint": True})
+config_2018.add_shift(name="hdamp_down", id=4, type="shape", aux={"disjoint": True})
 
 # FIXME: ensure JEC shifts get the same id every time
 for i, jec_source in enumerate(config_2018.x.jec["uncertainty_sources"]):
@@ -288,22 +289,6 @@ config_2018.set_aux("external_files", DotDict.wrap({
 
 }))
 
-# columns to keep after certain steps
-config_2018.set_aux("keep_columns", DotDict.wrap({
-    "ReduceEvents": {
-        "run", "luminosityBlock", "event",
-        "nJet", "Jet.pt", "Jet.eta", "Jet.btagDeepFlavB",
-        "nMuon", "Muon.pt", "Muon.eta",
-        "nElectron", "Electron.pt", "Electron.eta",
-        "LHEWeight.originalXWGTUP",
-        "PV.npvs",
-        "jet_high_multiplicity", "cat_array",
-    },
-    "CreateHistograms": {
-        "LHEWeight.originalXWGTUP",
-    },
-}))
-
 # event weight columns
 config_2018.set_aux("event_weights", ["normalization_weight", "pu_weight"])
 
@@ -317,3 +302,22 @@ add_categories(config_2018)
 
 # add variables
 add_variables(config_2018)
+
+# columns to keep after certain steps
+config_2018.set_aux("keep_columns", DotDict.wrap({
+    # test
+    "ReduceEvents": {
+        "run", "luminosityBlock", "event",
+        "nJet", "Jet.pt", "Jet.eta", "Jet.btagDeepFlavB",
+        "nMuon", "Muon.pt", "Muon.eta",
+        "nElectron", "Electron.pt", "Electron.eta",
+        "LHEWeight.originalXWGTUP",
+        "PV.npvs",
+        "jet_high_multiplicity", "cat_array", "deterministic_seed",
+    },
+
+    # test
+    "CreateHistograms": {
+        "LHEWeight.originalXWGTUP",
+    },
+}))

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -91,7 +91,7 @@ config_2018.set_aux("shift_groups", {})
 config_2018.set_aux("default_calibrator", "test")
 config_2018.set_aux("default_selector", "test")
 config_2018.set_aux("default_producer", "variables")
-config_2018.set_aux("default_ml_model", "test")
+config_2018.set_aux("default_ml_model", None)
 
 # 2018 luminosity with values in inverse pb and uncertainties taken from
 # https://twiki.cern.ch/twiki/bin/view/CMS/TWikiLUM?rev=171#LumiComb

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -91,7 +91,11 @@ config_2018.set_aux("category_groups", {})
 
 # variable groups for conveniently looping over certain variables
 # (used during plotting)
-config_2018.set_aux("variable_groups", {})
+config_2018.set_aux("variable_groups", {
+    "default": {
+        "HT", "nJet", "nElectron", "nMuon", "nDeepjet", "Electron1_pt", "Muon1_pt",
+    },
+})
 
 # shift groups for conveniently looping over certain shifts
 # (used during plotting)
@@ -168,12 +172,6 @@ config_2018.set_aux("default_producer", "variables")
 
 # event weight columns
 config_2018.set_aux("event_weights", ["normalization_weight", "pu_weight"])
-
-# file merging values
-# key -> dataset -> files per branch (-1 or not present = all)
-# TODO: maybe add selector name as additional layer
-config_2018.set_aux("file_merging", {
-})
 
 # versions per task family and optionally also dataset and shift
 # None can be used as a key to define a default value

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -100,9 +100,3 @@ def add_variables(config: od.Config) -> None:
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 3 $\eta$",
     )
-    config.add_variable(
-        name="test_model.n_muon",
-        null_value=-1,
-        binning=(4, -1.5, 2.5),
-        x_title="Predicted number of muons",
-    )

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -100,3 +100,9 @@ def add_variables(config: od.Config) -> None:
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 3 $\eta$",
     )
+    config.add_variable(
+        name="test_model.n_muon",
+        null_value=-1,
+        binning=(4, -1.5, 2.5),
+        x_title="Predicted number of muons",
+    )

--- a/ap/ml/__init__.py
+++ b/ap/ml/__init__.py
@@ -1,11 +1,12 @@
 # coding: utf-8
 
 """
-Definition of basic objects for describing ML models.
+Definition of basic objects for describing and creating ML models.
 """
 
 import copy as _copy
-from typing import Optional, Union, Sequence, List, Tuple, Any, Set
+from collections import OrderedDict
+from typing import Optional, Union, List, Tuple, Any, Set
 
 import law
 import order as od
@@ -18,38 +19,61 @@ ak = maybe_import("awkward")
 
 class MLModel(object):
     """
-    Subclass of :py:class:`ArrayFunction` that provides access to ML model meta data.
+    Minimal interface to ML models with connections to config objects (such as
+    py:class:`orderd.Config` or :py:class:`order.Dataset`) and, on an optional basis, to tasks.
 
-    .. py:attribute:: backend
-       type: type
+    Inheriting classes need to overwrite seven methods: :py:meth:`datasets`, :py:meth:`uses`,
+    :py:meth:`produces`, :py:meth:`output`, :py:meth:`open_model`, :py:meth:`train`, and
+    :py:meth:`evaluate`.
 
-       The backend class containing functions depending on the backend (e.g. opening models).
+    .. py:attribute:: name
+       type: str
 
-    .. py:attribute:: datasets
-       type: list
+       The unique name of this model.
 
-       A list of :py:class:`order.Dataset` instances that are required by the model training.
+    .. py:attribute:: config_inst
+       type: order.Config, None
+
+       Reference to the :py:class:`order.Config` object.
 
     .. py:attribute:: folds
        type: int
 
-       The number for folds to be used for k-fold cross-validation.
+       The number of folds for the k-fold cross-validation.
 
-    .. py:attribute: update_func
-       type: callable
+    .. py:attribute:: parameters
+       type: OrderedDict
 
-       The registered function defining what to update, or *None*.
+       A dictionary mapping parameter names to arbitrary values.
 
-    .. py:attribute:: training_func
-       type: callable
+    .. py:attribute:: used_datasets
+       type: set
+       read-only
 
-       The registered function performing the training, or *None*.
+       :py:class:`order.Dataset` instances that are used by the model training.
+
+    .. py:attribute:: used_columns
+       type: set
+       read-only
+
+       Column names or :py:class:`Route`'s that are used by this model.
+
+    .. py:attribute:: produced_columns
+       type: set
+       read-only
+
+       Column names or :py:class:`Route`'s that are produces by this model.
     """
 
     _instances = {}
 
     @classmethod
     def new(cls, name: str, *args, **kwargs) -> "MLModel":
+        """
+        Creates a new instance with *name* and all *args* and *kwargs*, adds it to the instance
+        cache and returns it. A *ValueError* is raised in case an instance with the same name was
+        registered before.
+        """
         # check if the instance is already registered
         if name in cls._instances:
             raise ValueError(f"a model named '{name}' was already registered ({cls.get(name)})")
@@ -61,6 +85,10 @@ class MLModel(object):
 
     @classmethod
     def get(cls, name: str, copy: bool = False) -> "MLModel":
+        """
+        Returns a previously registered instance named *name* and optionally copies it when *copy*
+        is *True*. A *ValueError* is raised when no instance was found with that name.
+        """
         if name not in cls._instances:
             raise ValueError(f"no model named named '{name}' found")
 
@@ -71,7 +99,7 @@ class MLModel(object):
         name: str,
         *,
         config_inst: Optional[od.Config] = None,
-        parameters: Optional[Sequence[Tuple[str, Any]]] = None,
+        parameters: Optional[OrderedDict] = None,
         folds: int = 2,
     ):
         super().__init__()
@@ -80,7 +108,7 @@ class MLModel(object):
         self.name = name
         self.config_inst = None
         self.folds = folds
-        self.parameters = parameters or []
+        self.parameters = parameters or OrderedDict()
 
         # cache for attributes that need to be defined in inheriting classes
         self._used_datasets = None
@@ -97,7 +125,10 @@ class MLModel(object):
     def __repr__(self):
         return f"<{self.__class__.__name__} '{self.name}' at {hex(id(self))}>"
 
-    def _format_value(self, value):
+    def _format_value(self, value: Any) -> str:
+        """
+        Formats any paramter *value* to a readable string.
+        """
         if isinstance(value, (list, tuple)):
             return "_".join(map(self._format_value, value))
         if isinstance(value, bool):
@@ -109,17 +140,26 @@ class MLModel(object):
         # any other case
         return str(value)
 
-    def _join_parameter_pairs(self) -> str:
+    def _join_parameter_pairs(self, only_significant: bool = True) -> str:
+        """
+        Returns a joined string representation of all significant paramters.
+        """
         return "__".join(
             f"{name}_{self._format_value(value)}"
             for name, value in self.parameter_pairs(only_significant=True)
         )
 
-    def set_config(self, config_inst: od.Config) -> None:
-        self.config_inst = config_inst
-
     def parameter_pairs(self, only_significant: bool = False) -> List[Tuple[str, Any]]:
-        return self.parameters
+        """
+        Returns a list of all parameter name-value tuples.
+        """
+        return list(self.parameters.items())
+
+    def set_config(self, config_inst: od.Config) -> None:
+        """
+        Sets the :py:attr:`config_inst` attribute to *config_inst*.
+        """
+        self.config_inst = config_inst
 
     @property
     def used_datasets(self) -> Set[od.Dataset]:
@@ -140,18 +180,35 @@ class MLModel(object):
         return self._produced_columns
 
     def datasets(self) -> Set[od.Dataset]:
+        """
+        Returns a set of all required datasets. To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def uses(self) -> Set[Union[Route, str]]:
+        """
+        Returns a set of all required columns. To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def produces(self) -> Set[Union[Route, str]]:
+        """
+        Returns a set of all produced columns. To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def output(self, task: law.Task) -> Any:
+        """
+        Returns a structure of :py:class:`ap.util.FunctionArgs` objects that can be used by *task*
+        to create actual output target objects. To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def open_model(self, output: Any) -> Any:
+        """
+        Implemenents the opening of a trained model from *output* (corresponding to the structure
+        returned by :py:meth:`output`). To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def train(
@@ -160,6 +217,10 @@ class MLModel(object):
         input: Any,
         output: Any,
     ) -> None:
+        """
+        Performs the creation and training of a model, being passed a *task* and its *input* and
+        *output*. To be implemented in subclasses.
+        """
         raise NotImplementedError()
 
     def evaluate(
@@ -170,4 +231,10 @@ class MLModel(object):
         fold_indices: ak.Array,
         events_used_in_training: bool = False,
     ) -> None:
+        """
+        Performs the model evaluation for a *task* on a chunk of *events*. The list of *models*
+        corresponds to the number of folds generated by this model, and the already evaluated
+        *fold_indices* for this event chunk that might used depending on *events_used_in_training*.
+        To be implemented in subclasses.
+        """
         raise NotImplementedError()

--- a/ap/ml/__init__.py
+++ b/ap/ml/__init__.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+
+"""
+Definition of basic objects for describing ML models.
+"""
+
+import copy as _copy
+from typing import Optional, Union, Sequence, List, Tuple, Any, Set
+
+import law
+import order as od
+
+from ap.columnar_util import Route
+
+
+class MLModel(object):
+    """
+    Subclass of :py:class:`ArrayFunction` that provides access to ML model meta data.
+
+    .. py:attribute:: backend
+       type: type
+
+       The backend class containing functions depending on the backend (e.g. opening models).
+
+    .. py:attribute:: datasets
+       type: list
+
+       A list of :py:class:`order.Dataset` instances that are required by the model training.
+
+    .. py:attribute:: folds
+       type: int
+
+       The number for folds to be used for k-fold cross-validation.
+
+    .. py:attribute: update_func
+       type: callable
+
+       The registered function defining what to update, or *None*.
+
+    .. py:attribute:: training_func
+       type: callable
+
+       The registered function performing the training, or *None*.
+    """
+
+    _instances = {}
+
+    @classmethod
+    def new(cls, name: str, *args, **kwargs) -> "MLModel":
+        # check if the instance is already registered
+        if name in cls._instances:
+            raise ValueError(f"a model named '{name}' was already registered ({cls.get(name)})")
+
+        # create it
+        cls._instances[name] = cls(name, *args, **kwargs)
+
+        return cls._instances[name]
+
+    @classmethod
+    def get(cls, name: str, copy: bool = False) -> "MLModel":
+        if name not in cls._instances:
+            raise ValueError(f"no model named named '{name}' found")
+
+        return _copy.copy(cls._instances[name]) if copy else cls._instances[name]
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        config_inst: Optional[od.Config] = None,
+        parameters: Optional[Sequence[Tuple[str, Any]]] = None,
+        folds: int = 2,
+    ):
+        super().__init__()
+
+        # store attributes
+        self.name = name
+        self.config_inst = config_inst
+        self.folds = folds
+        self.parameters = parameters or []
+
+        # cache for attributes that need to be defined in inheriting classes
+        self._datasets = None
+        self._uses = None
+        self._produces = None
+
+    def __str__(self):
+        return f"{self.__class__.__name__}__{self.name}"
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} '{self.name}' at {hex(id(self))}>"
+
+    def _join_parameter_pairs(self) -> str:
+        return "__".join(f"{name}_{value}" for name, value in self.parameter_pairs())
+
+    def parameter_pairs(self) -> List[Tuple[str, Any]]:
+        return self.parameters
+
+    @property
+    def datasets(self) -> Set[od.Dataset]:
+        if self._datasets is None:
+            self._datasets = set(self.define_datasets())
+        return self._datasets
+
+    @property
+    def uses(self) -> Set[Union[Route, str]]:
+        if self._uses is None:
+            self._uses = set(self.define_used_columns())
+        return self._uses
+
+    @property
+    def produces(self) -> Set[Union[Route, str]]:
+        if self._produces is None:
+            self._produces = set(self.define_produced_columns())
+        return self._produces
+
+    def define_datasets(self) -> Set[od.Dataset]:
+        raise NotImplementedError()
+
+    def define_used_columns(self) -> Set[Union[Route, str]]:
+        raise NotImplementedError()
+
+    def define_produced_columns(self) -> Set[Union[Route, str]]:
+        raise NotImplementedError()
+
+    def define_output(self, task: law.Task) -> Any:
+        raise NotImplementedError()
+
+    def open_model(self, output: Any) -> Any:
+        raise NotImplementedError()
+
+    def train(self, input: Any, output: Any) -> None:
+        raise NotImplementedError()
+
+    def evaluate(self) -> None:
+        raise NotImplementedError()

--- a/ap/ml/test.py
+++ b/ap/ml/test.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+"""
+Dummy training script.
+"""
+
+from ap.ml import MLModel
+from ap.util import FunctionArgs
+from ap.columnar_util import set_ak_column
+
+
+class TestModel(MLModel):
+
+    def define_datasets(self):
+        return {
+            self.config_inst.get_dataset("st_tchannel_t"),
+            self.config_inst.get_dataset("tt_sl"),
+        }
+
+    def define_used_columns(self):
+        return {"ht", "n_jet", "n_muon", "n_electron", "normalization_weight"}
+
+    def define_produced_columns(self):
+        return {f"{self.name}.n_muon", f"{self.name}.n_electron"}
+
+    def define_output(self, task):
+        return FunctionArgs(f"mlmodel_f{task.fold}of{self.folds}", dir=True)
+
+    def open_model(self, output):
+        import tensorflow as tf
+        return tf.keras.models.load_model(output.path)
+
+    def train(self, task, input, output):
+        import tensorflow as tf
+
+        # define a dummy NN
+        x = tf.keras.Input(shape=(2,))
+        a1 = tf.keras.layers.Dense(10, activation="elu")(x)
+        y = tf.keras.layers.Dense(2, activation="softmax")(a1)
+        model = tf.keras.Model(inputs=x, outputs=y)
+
+        # the output is just a single directory target
+        output.parent.touch()
+        model.save(output.path)
+
+    def evaluate(self, task, models, events, events_used_in_training=False):
+        # dummy evaluation that does not need the models at all
+        set_ak_column(events, f"{self.name}.n_muon", 1)
+        set_ak_column(events, f"{self.name}.n_electron", 1)
+
+
+# pre-register models
+TestModel.new("test", folds=5)

--- a/ap/ml/test.py
+++ b/ap/ml/test.py
@@ -4,35 +4,63 @@
 Dummy training script.
 """
 
+from typing import List, Any, Set, Union
+
+import law
+import order as od
+
 from ap.ml import MLModel
-from ap.util import FunctionArgs
-from ap.columnar_util import set_ak_column
+from ap.util import maybe_import, FunctionArgs
+from ap.columnar_util import Route, set_ak_column
+
+ak = maybe_import("awkward")
+tf = maybe_import("tensorflow")
 
 
 class TestModel(MLModel):
 
-    def define_datasets(self):
+    def set_config(self, *args, **kwargs):
+        super().set_config(*args, **kwargs)
+
+        # dynamically add variables for the quantities produced by thia model
+        if f"{self.name}.n_muon" not in self.config_inst.variables:
+            self.config_inst.add_variable(
+                name=f"{self.name}.n_muon",
+                null_value=-1,
+                binning=(4, -1.5, 2.5),
+                x_title="Predicted number of muons",
+            )
+            self.config_inst.add_variable(
+                name=f"{self.name}.n_electron",
+                null_value=-1,
+                binning=(4, -1.5, 2.5),
+                x_title="Predicted number of electrons",
+            )
+
+    def datasets(self) -> Set[od.Dataset]:
         return {
             self.config_inst.get_dataset("st_tchannel_t"),
             self.config_inst.get_dataset("tt_sl"),
         }
 
-    def define_used_columns(self):
+    def uses(self) -> Set[Union[Route, str]]:
         return {"ht", "n_jet", "n_muon", "n_electron", "normalization_weight"}
 
-    def define_produced_columns(self):
+    def produces(self) -> Set[Union[Route, str]]:
         return {f"{self.name}.n_muon", f"{self.name}.n_electron"}
 
-    def define_output(self, task):
+    def output(self, task: law.Task) -> FunctionArgs:
         return FunctionArgs(f"mlmodel_f{task.fold}of{self.folds}", dir=True)
 
-    def open_model(self, output):
-        import tensorflow as tf
+    def open_model(self, output: law.LocalDirectoryTarget) -> tf.keras.models.Model:
         return tf.keras.models.load_model(output.path)
 
-    def train(self, task, input, output):
-        import tensorflow as tf
-
+    def train(
+        self,
+        task: law.Task,
+        input: Any,
+        output: law.LocalDirectoryTarget,
+    ) -> None:
         # define a dummy NN
         x = tf.keras.Input(shape=(2,))
         a1 = tf.keras.layers.Dense(10, activation="elu")(x)
@@ -43,8 +71,15 @@ class TestModel(MLModel):
         output.parent.touch()
         model.save(output.path)
 
-    def evaluate(self, task, models, events, events_used_in_training=False):
-        # dummy evaluation that does not need the models at all
+    def evaluate(
+        self,
+        task: law.Task,
+        events: ak.Array,
+        models: List[Any],
+        fold_indices: ak.Array,
+        events_used_in_training: bool = False,
+    ) -> None:
+        # fake evaluation
         set_ak_column(events, f"{self.name}.n_muon", 1)
         set_ak_column(events, f"{self.name}.n_electron", 1)
 

--- a/ap/ml/test.py
+++ b/ap/ml/test.py
@@ -50,4 +50,4 @@ class TestModel(MLModel):
 
 
 # pre-register models
-TestModel.new("test", folds=5)
+TestModel.new("test_model", folds=3)

--- a/ap/production/features.py
+++ b/ap/production/features.py
@@ -7,7 +7,7 @@ Column production methods related to higher-level features.
 from ap.production import producer
 from ap.production.weights import event_weights
 from ap.util import maybe_import
-from ap.columnar_util import EMPTY, set_ak_column, has_ak_column
+from ap.columnar_util import EMPTY, set_ak_column
 
 ak = maybe_import("awkward")
 
@@ -37,9 +37,6 @@ def extract(ak_array: ak.Array, idx: int) -> ak.Array:
     },
 )
 def variables(events: ak.Array, **kwargs) -> ak.Array:
-    if has_ak_column(events, "HT"):
-        return events
-
     set_ak_column(events, "HT", ak.sum(events.Jet.pt, axis=1))
     set_ak_column(events, "nJet", ak.num(events.Jet.pt, axis=1))
     set_ak_column(events, "nElectron", ak.num(events.Electron.pt, axis=1))

--- a/ap/production/features.py
+++ b/ap/production/features.py
@@ -26,7 +26,7 @@ ak = maybe_import("awkward")
     },
     shifts={jet_energy_shifts},
 )
-def variables(events: ak.Array, **kwargs) -> ak.Array:
+def variables(self, events: ak.Array, **kwargs) -> ak.Array:
     set_ak_column(events, "ht", ak.sum(events.Jet.pt, axis=1))
     set_ak_column(events, "n_jet", ak.num(events.Jet.pt, axis=1))
     set_ak_column(events, "n_electron", ak.num(events.Electron.pt, axis=1))

--- a/ap/production/normalization.py
+++ b/ap/production/normalization.py
@@ -12,7 +12,7 @@ import order as od
 from ap.production import Producer, producer
 from ap.production.processes import process_ids
 from ap.util import maybe_import
-from ap.columnar_util import set_ak_column, has_ak_column
+from ap.columnar_util import set_ak_column
 
 np = maybe_import("numpy")
 sp = maybe_import("scipy")
@@ -37,11 +37,8 @@ def normalization_weights(
     *dataset_inst* and the sum of event weights from *selection_stats* to assign each event a
     normalization weight.
     """
-    if has_ak_column(events, "normalization_weight"):
-        return events
-
     # add process ids
-    events = process_ids(events, config_inst=config_inst, dataset_inst=dataset_inst, **kwargs)
+    process_ids(events, config_inst=config_inst, dataset_inst=dataset_inst, **kwargs)
 
     # stop here for data
     if dataset_inst.is_data:

--- a/ap/production/normalization.py
+++ b/ap/production/normalization.py
@@ -25,6 +25,7 @@ ak = maybe_import("awkward")
     produces={process_ids, "normalization_weight"},
 )
 def normalization_weights(
+    self,
     events: ak.Array,
     selection_stats: Dict[str, Union[int, float]],
     xs_table: sp.sparse.lil.lil_matrix,

--- a/ap/production/pileup.py
+++ b/ap/production/pileup.py
@@ -19,6 +19,7 @@ ak = maybe_import("awkward")
     produces={"pu_weight", "pu_weight_minbias_xs_up", "pu_weight_minbias_xs_down"},
 )
 def pu_weights(
+    self,
     events: ak.Array,
     pu_weights: ak.Array,
     dataset_inst: od.Dataset,

--- a/ap/production/pileup.py
+++ b/ap/production/pileup.py
@@ -9,7 +9,7 @@ import order as od
 
 from ap.production import Producer, producer
 from ap.util import maybe_import
-from ap.columnar_util import set_ak_column, has_ak_column
+from ap.columnar_util import set_ak_column
 
 ak = maybe_import("awkward")
 
@@ -28,9 +28,6 @@ def pu_weights(
     Based on the number of primary vertices, assigns each event pileup weights using the profile
     of pileup ratios *pu_weights* that is provided by the requires and setup functions below.
     """
-    if has_ak_column(events, "pu_weight"):
-        return events
-
     # stop here for data
     if dataset_inst.is_data:
         return events

--- a/ap/production/processes.py
+++ b/ap/production/processes.py
@@ -8,7 +8,7 @@ import order as od
 
 from ap.production import producer
 from ap.util import maybe_import
-from ap.columnar_util import set_ak_column, has_ak_column
+from ap.columnar_util import set_ak_column
 
 ak = maybe_import("awkward")
 
@@ -23,9 +23,6 @@ def process_ids(events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Arra
     *dataset_inst*. This is rather a dummy method and should be further implemented depending on
     future needs (e.g. for sample stitching).
     """
-    if has_ak_column(events, "process_id"):
-        return events
-
     # trivial case
     if len(dataset_inst.processes) != 1:
         raise NotImplementedError(

--- a/ap/production/processes.py
+++ b/ap/production/processes.py
@@ -17,7 +17,7 @@ ak = maybe_import("awkward")
     uses={"event"},
     produces={"process_id"},
 )
-def process_ids(events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Array:
+def process_ids(self, events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Array:
     """
     Assigns each event a single process id, based on the first process that is registered for the
     *dataset_inst*. This is rather a dummy method and should be further implemented depending on

--- a/ap/production/seeds.py
+++ b/ap/production/seeds.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Methods related to creating event and object seeds during calibration.
+Methods related to creating event and object seeds.
 """
 
 import hashlib
@@ -9,7 +9,7 @@ from typing import Callable
 
 import law
 
-from ap.calibration import calibrator
+from ap.production import producer
 from ap.util import maybe_import, primes
 from ap.columnar_util import Route, set_ak_column
 
@@ -17,7 +17,7 @@ np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
 
-@calibrator(
+@producer(
     uses={
         # global columns for event seed
         "event", "nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV",
@@ -29,6 +29,7 @@ ak = maybe_import("awkward")
     produces={"deterministic_seed"},
 )
 def deterministic_event_seeds(
+    self,
     events: ak.Array,
     create_seed: Callable,
     **kwargs,
@@ -95,11 +96,12 @@ def deterministic_event_seeds_setup(
     call_kwargs["create_seed"] = np.vectorize(create_seed, otypes=[np.uint64])
 
 
-@calibrator(
+@producer(
     uses={deterministic_event_seeds, "nJet"},
     produces={"Jet.deterministic_seed"},
 )
 def deterministic_jet_seeds(
+    self,
     events: ak.Array,
     create_seed: Callable,
     **kwargs,
@@ -133,16 +135,17 @@ def deterministic_jet_seeds(
     return events
 
 
-@calibrator(
+@producer(
     uses={deterministic_event_seeds, deterministic_jet_seeds},
     produces={deterministic_event_seeds, deterministic_jet_seeds},
 )
 def deterministic_seeds(
+    self,
     events: ak.Array,
     **kwargs,
 ) -> ak.Array:
     """
-    Wrapper calibrator that invokes :py:func:`deterministic_event_seeds` and
+    Wrapper producer that invokes :py:func:`deterministic_event_seeds` and
     :py:func:`deterministic_jet_seeds`.
     """
     # create the event seeds

--- a/ap/production/seeds.py
+++ b/ap/production/seeds.py
@@ -8,6 +8,7 @@ import hashlib
 from typing import Callable
 
 import law
+import order as od
 
 from ap.production import producer
 from ap.util import maybe_import, primes
@@ -20,7 +21,8 @@ ak = maybe_import("awkward")
 @producer(
     uses={
         # global columns for event seed
-        "event", "nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV",
+        "run", "luminosityBlock", "event", "nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon",
+        "nElectron", "nTau", "nSV",
         # first-object columns for event seed
         "Tau.jetIdx", "Tau.decayMode",
         "Muon.jetIdx", "Muon.nStations",
@@ -32,6 +34,7 @@ def deterministic_event_seeds(
     self,
     events: ak.Array,
     create_seed: Callable,
+    dataset_inst: od.Dataset,
     **kwargs,
 ) -> ak.Array:
     """
@@ -50,8 +53,9 @@ def deterministic_event_seeds(
     seed = create_seed(events.event)
     prime_offset = 3
 
-    # get global integers
-    global_fields = ["nGenJet", "nGenPart", "nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV"]
+    # get global integers, with a slight difference between data and mc
+    global_fields = ["nGenJet", "nGenPart"] if dataset_inst.is_mc else ["run", "luminosityBlock"]
+    global_fields.extend(["nJet", "nPhoton", "nMuon", "nElectron", "nTau", "nSV"])
     for i, f in enumerate(global_fields, prime_offset):
         seed = seed + primes[i] * (events[f] if f in events.fields else ak.num(events[f[1:]]))
 

--- a/ap/production/weights.py
+++ b/ap/production/weights.py
@@ -10,7 +10,7 @@ from ap.production import Producer, producer
 from ap.production.pileup import pu_weights
 from ap.production.normalization import normalization_weights
 from ap.util import maybe_import
-from ap.columnar_util import set_ak_column, has_ak_column
+from ap.columnar_util import set_ak_column
 
 ak = maybe_import("awkward")
 
@@ -24,9 +24,6 @@ def top_pt_weights(events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.A
     Adds a dummy top pt weight and its variations to *events* in case *dataset_inst* represents a
     ttbar dataset.
     """
-    if has_ak_column(events, "top_pt_weight"):
-        return events
-
     # skip when not a ttbar dataset
     if not dataset_inst.x("is_ttbar", False):
         return events
@@ -50,13 +47,13 @@ def event_weights(events: ak.Array, **kwargs) -> ak.Array:
     might possibly change any of the weights.
     """
     # compute normalization weights
-    events = normalization_weights(events, **kwargs)
+    normalization_weights(events, **kwargs)
 
     # compute pu weights
-    events = pu_weights(events, **kwargs)
+    pu_weights(events, **kwargs)
 
     # compute top pt weights
-    events = top_pt_weights(events, **kwargs)
+    top_pt_weights(events, **kwargs)
 
     return events
 

--- a/ap/production/weights.py
+++ b/ap/production/weights.py
@@ -19,7 +19,7 @@ ak = maybe_import("awkward")
     uses={"Jet.pt"},
     produces={"top_pt_weight", "top_pt_weight_up", "top_pt_weight_down"},
 )
-def top_pt_weights(events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Array:
+def top_pt_weights(self, events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Array:
     """
     Adds a dummy top pt weight and its variations to *events* in case *dataset_inst* represents a
     ttbar dataset.
@@ -41,7 +41,7 @@ def top_pt_weights(events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.A
     produces={normalization_weights, pu_weights, top_pt_weights},
     shifts={"minbias_xs_up", "minbias_xs_down"},
 )
-def event_weights(events: ak.Array, **kwargs) -> ak.Array:
+def event_weights(self, events: ak.Array, **kwargs) -> ak.Array:
     """
     Opinionated wrapper of several event weight producers. It declares dependence all shifts that
     might possibly change any of the weights.

--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -24,7 +24,7 @@ class Selector(TaskArrayFunction):
 
         # flag denoting whether this selector is exposed, i.e., callable from tasks and returning
         # an actual SelectionResult
-        self.exposed = False
+        self.exposed = exposed
 
 
 def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Callable]:

--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -19,6 +19,13 @@ class Selector(TaskArrayFunction):
     # dedicated instance cache
     _instances = {}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # flag denoting whether this selector is exposed, i.e., callable from tasks and returning
+        # an actual SelectionResult
+        self.exposed = False
+
 
 def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Callable]:
     """
@@ -29,6 +36,18 @@ def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Calla
         return Selector.new(func, **kwargs)
 
     return decorator(func) if func else decorator
+
+
+def expose(selector: Optional[Selector] = None) -> Selector:
+    """
+    Decorator that wraps :py:class:`Selector` objects and sets their :py:attr:`exposed` attribute to
+    *True*.
+    """
+    def decorator(selector):
+        selector.exposed = True
+        return selector
+
+    return decorator(selector) if selector else decorator
 
 
 class SelectionResult(object):

--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -19,12 +19,12 @@ class Selector(TaskArrayFunction):
     # dedicated instance cache
     _instances = {}
 
-    def __init__(self, *args, expose=False, **kwargs):
+    def __init__(self, *args, exposed=False, **kwargs):
         super().__init__(*args, **kwargs)
 
         # flag denoting whether this selector is exposed, i.e., callable from tasks and returning
         # an actual SelectionResult
-        self.expose = False
+        self.exposed = False
 
 
 def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Callable]:

--- a/ap/selection/__init__.py
+++ b/ap/selection/__init__.py
@@ -19,12 +19,12 @@ class Selector(TaskArrayFunction):
     # dedicated instance cache
     _instances = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, expose=False, **kwargs):
         super().__init__(*args, **kwargs)
 
         # flag denoting whether this selector is exposed, i.e., callable from tasks and returning
         # an actual SelectionResult
-        self.exposed = False
+        self.expose = False
 
 
 def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Callable]:
@@ -36,18 +36,6 @@ def selector(func: Optional[Callable] = None, **kwargs) -> Union[Selector, Calla
         return Selector.new(func, **kwargs)
 
     return decorator(func) if func else decorator
-
-
-def expose(selector: Optional[Selector] = None) -> Selector:
-    """
-    Decorator that wraps :py:class:`Selector` objects and sets their :py:attr:`exposed` attribute to
-    *True*.
-    """
-    def decorator(selector):
-        selector.exposed = True
-        return selector
-
-    return decorator(selector) if selector else decorator
 
 
 class SelectionResult(object):

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -136,7 +136,7 @@ def sel_1mu_ge2b_highHT(events):
     return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)
 
 
-@selector(uses={req_jet}, produces={"jet_high_multiplicity"}, expose=True)
+@selector(uses={req_jet}, produces={"jet_high_multiplicity"}, exposed=True)
 def jet_selection_test(events, stats, **kwargs):
     # example cuts:
     # - require at least 4 jets with pt>30, eta<2.4
@@ -153,7 +153,7 @@ def jet_selection_test(events, stats, **kwargs):
     return SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices})
 
 
-@selector(uses={req_deepjet}, expose=True)
+@selector(uses={req_deepjet}, exposed=True)
 def deepjet_selection_test(events, stats):
     deepjet_indices = req_deepjet(events)
     deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1
@@ -161,7 +161,7 @@ def deepjet_selection_test(events, stats):
     return SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices})
 
 
-@selector(uses={req_muon}, expose=True)
+@selector(uses={req_muon}, exposed=True)
 def muon_selection_test(events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
@@ -173,7 +173,7 @@ def muon_selection_test(events, stats):
     return SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices})
 
 
-@selector(uses={req_electron}, expose=True)
+@selector(uses={req_electron}, exposed=True)
 def electron_selection_test(events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
@@ -185,7 +185,7 @@ def electron_selection_test(events, stats):
     return SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices})
 
 
-@selector(uses={req_muon, req_electron}, expose=True)
+@selector(uses={req_muon, req_electron}, exposed=True)
 def lepton_selection_test(events, stats):
     # example cuts:
     # - require exactly one lepton with pt>25, eta<2.4 and tight Id
@@ -212,7 +212,7 @@ def lepton_selection_test(events, stats):
     shifts={
         jet_energy_shifts,
     },
-    expose=True,
+    exposed=True,
 )
 def test(
     events: ak.Array,

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -20,7 +20,7 @@ np = maybe_import("numpy")
 # pseudo-selectors for declaring dependence on shifts
 
 @selector
-def jet_energy_shifts(events):
+def jet_energy_shifts(self, events):
     return events
 
 
@@ -39,105 +39,105 @@ def update(self, config_inst, dataset_inst, **kwargs):
 # object definitions
 # TODO: return masks instead of indices and build indices as late as possible
 @selector(uses={"Jet.pt", "Jet.eta"})
-def req_jet(events):
+def req_jet(self, events):
     mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4)
     return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
 
 
 @selector(uses={"Electron.pt", "Electron.eta", "Electron.cutBased"})
-def req_electron(events):
+def req_electron(self, events):
     mask = (events.Electron.pt > 25) & (abs(events.Electron.eta) < 2.4) & (events.Electron.cutBased == 4)
     return ak.argsort(events.Electron.pt, axis=-1, ascending=False)[mask]
 
 
 @selector(uses={"Muon.pt", "Muon.eta", "Muon.tightId"})
-def req_muon(events):
+def req_muon(self, events):
     mask = (events.Muon.pt > 25) & (abs(events.Muon.eta) < 2.4) & (events.Muon.tightId)
     return ak.argsort(events.Muon.pt, axis=-1, ascending=False)[mask]
 
 
 @selector(uses={"Jet.pt", "Jet.eta"})
-def req_forwardJet(events):
+def req_forwardJet(self, events):
     mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) > 2.4) & (abs(events.Jet.eta) < 5.0)
     return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
 
 
 @selector(uses={"Jet.pt", "Jet.eta", "Jet.btagDeepFlavB"})
-def req_deepjet(events):
+def req_deepjet(self, events):
     mask = (events.Jet.pt > 30) & (abs(events.Jet.eta) < 2.4) & (events.Jet.btagDeepFlavB > 0.3)
     return ak.argsort(events.Jet.pt, axis=-1, ascending=False)[mask]
 
 
 @selector(uses={req_jet})
-def var_nJet(events):
+def var_nJet(self, events):
     return ak.num(req_jet(events), axis=1)
 
 
 @selector(uses={req_deepjet})
-def var_nDeepjet(events):
+def var_nDeepjet(self, events):
     return ak.num(req_deepjet(events), axis=1)
 
 
 @selector(uses={req_electron})
-def var_nElectron(events):
+def var_nElectron(self, events):
     return ak.num(req_electron(events), axis=1)
 
 
 @selector(uses={req_muon})
-def var_nMuon(events):
+def var_nMuon(self, events):
     return ak.num(req_muon(events), axis=1)
 
 
 @selector(uses={req_jet, "Jet.pt"})
-def var_HT(events):
+def var_HT(self, events):
     jet_pt_sorted = events.Jet.pt[req_jet(events)]
     return ak.sum(jet_pt_sorted, axis=1)
 
 
 # selection for the main categories
 @selector(uses={var_nMuon, var_nElectron})
-def sel_1e(events):
+def sel_1e(self, events):
     return (var_nMuon(events) == 0) & (var_nElectron(events) == 1)
 
 
 @selector(uses={var_nMuon, var_nElectron})
-def sel_1mu(events):
+def sel_1mu(self, events):
     return (var_nMuon(events) == 1) & (var_nElectron(events) == 0)
 
 
 # selection for the sub-categories
 @selector(uses={sel_1e, var_nDeepjet})
-def sel_1e_eq1b(events):
+def sel_1e_eq1b(self, events):
     return (sel_1e(events)) & (var_nDeepjet(events) == 1)
 
 
 @selector(uses={sel_1e, var_nDeepjet})
-def sel_1e_ge2b(events):
+def sel_1e_ge2b(self, events):
     return (sel_1e(events)) & (var_nDeepjet(events) >= 2)
 
 
 @selector(uses={sel_1mu, var_nDeepjet})
-def sel_1mu_eq1b(events):
+def sel_1mu_eq1b(self, events):
     return (sel_1mu(events)) & (var_nDeepjet(events) == 1)
 
 
 @selector(uses={sel_1mu, var_nDeepjet})
-def sel_1mu_ge2b(events):
+def sel_1mu_ge2b(self, events):
     return (sel_1mu(events)) & (var_nDeepjet(events) >= 2)
 
 
 @selector(uses={sel_1mu_ge2b, var_HT})
-def sel_1mu_ge2b_lowHT(events):
+def sel_1mu_ge2b_lowHT(self, events):
     return (sel_1mu_ge2b(events)) & (var_HT(events) <= 300)
 
 
 @selector(uses={sel_1mu_ge2b, var_HT})
-def sel_1mu_ge2b_highHT(events):
+def sel_1mu_ge2b_highHT(self, events):
     return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)
 
 
 @selector(uses={req_jet}, produces={"jet_high_multiplicity"}, exposed=True)
-def jet_selection_test(events, stats, **kwargs):
+def jet_selection_test(self, events, stats, **kwargs):
     # example cuts:
     # - require at least 4 jets with pt>30, eta<2.4
     # example columns:
@@ -154,7 +154,7 @@ def jet_selection_test(events, stats, **kwargs):
 
 
 @selector(uses={req_deepjet}, exposed=True)
-def deepjet_selection_test(events, stats):
+def deepjet_selection_test(self, events, stats):
     deepjet_indices = req_deepjet(events)
     deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1
 
@@ -162,7 +162,7 @@ def deepjet_selection_test(events, stats):
 
 
 @selector(uses={req_muon}, exposed=True)
-def muon_selection_test(events, stats):
+def muon_selection_test(self, events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
 
@@ -174,7 +174,7 @@ def muon_selection_test(events, stats):
 
 
 @selector(uses={req_electron}, exposed=True)
-def electron_selection_test(events, stats):
+def electron_selection_test(self, events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
 
@@ -186,7 +186,7 @@ def electron_selection_test(events, stats):
 
 
 @selector(uses={req_muon, req_electron}, exposed=True)
-def lepton_selection_test(events, stats):
+def lepton_selection_test(self, events, stats):
     # example cuts:
     # - require exactly one lepton with pt>25, eta<2.4 and tight Id
 
@@ -215,6 +215,7 @@ def lepton_selection_test(events, stats):
     exposed=True,
 )
 def test(
+    self,
     events: ak.Array,
     stats: defaultdict,
     config_inst: od.Config,
@@ -400,6 +401,7 @@ def req_clean_delta_r_match_jet_lepton(
 
 @selector(uses={delta_r_jet_lepton})
 def jet_lepton_delta_r_cleaning_selection(
+    self,
     events: ak.Array,
     stats: Dict[str, Union[int, float]],
     threshold: float = 0.4,
@@ -418,6 +420,7 @@ def jet_lepton_delta_r_cleaning_selection(
 
 @selector(uses={jet_lepton_delta_r_cleaning_selection})
 def jet_lepton_delta_r_cleaning(
+    self,
     events: ak.Array,
     stats: Dict[str, Union[int, float]],
     threshold: float = 0.4,

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, Optional, Union, Tuple
 
 import order as od
 
-from ap.selection import selector, expose, SelectionResult
+from ap.selection import selector, SelectionResult
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
 
@@ -136,8 +136,7 @@ def sel_1mu_ge2b_highHT(events):
     return (sel_1mu_ge2b(events)) & (var_HT(events) > 300)
 
 
-@expose
-@selector(uses={req_jet}, produces={"jet_high_multiplicity"})
+@selector(uses={req_jet}, produces={"jet_high_multiplicity"}, expose=True)
 def jet_selection_test(events, stats, **kwargs):
     # example cuts:
     # - require at least 4 jets with pt>30, eta<2.4
@@ -154,8 +153,7 @@ def jet_selection_test(events, stats, **kwargs):
     return SelectionResult(steps={"Jet": jet_sel}, objects={"Jet": jet_indices})
 
 
-@expose
-@selector(uses={req_deepjet})
+@selector(uses={req_deepjet}, expose=True)
 def deepjet_selection_test(events, stats):
     deepjet_indices = req_deepjet(events)
     deepjet_sel = ak.num(deepjet_indices, axis=1) >= 1
@@ -163,8 +161,7 @@ def deepjet_selection_test(events, stats):
     return SelectionResult(steps={"Deepjet": deepjet_sel}, objects={"Deepjet": deepjet_indices})
 
 
-@expose
-@selector(uses={req_muon})
+@selector(uses={req_muon}, expose=True)
 def muon_selection_test(events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
@@ -176,8 +173,7 @@ def muon_selection_test(events, stats):
     return SelectionResult(steps={"Muon": muon_sel}, objects={"Muon": muon_indices})
 
 
-@expose
-@selector(uses={req_electron})
+@selector(uses={req_electron}, expose=True)
 def electron_selection_test(events, stats):
     # example cuts:
     # - require exactly one muon with pt>25, eta<2.4 and tight Id
@@ -189,8 +185,7 @@ def electron_selection_test(events, stats):
     return SelectionResult(steps={"Electron": electron_sel}, objects={"Electron": electron_indices})
 
 
-@expose
-@selector(uses={req_muon, req_electron})
+@selector(uses={req_muon, req_electron}, expose=True)
 def lepton_selection_test(events, stats):
     # example cuts:
     # - require exactly one lepton with pt>25, eta<2.4 and tight Id
@@ -206,7 +201,6 @@ def lepton_selection_test(events, stats):
     )
 
 
-@expose
 @selector(
     uses={
         jet_selection_test, lepton_selection_test, deepjet_selection_test,
@@ -218,6 +212,7 @@ def lepton_selection_test(events, stats):
     shifts={
         jet_energy_shifts,
     },
+    expose=True,
 )
 def test(
     events: ak.Array,

--- a/ap/tasks/calibration.py
+++ b/ap/tasks/calibration.py
@@ -19,7 +19,7 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
 
     update_calibrator = True
 
-    shifts = {GetDatasetLFNs}
+    shifts = set(GetDatasetLFNs.shifts)
 
     def workflow_requires(self):
         reqs = super().workflow_requires()

--- a/ap/tasks/calibration.py
+++ b/ap/tasks/calibration.py
@@ -86,7 +86,7 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
             msg = f"iterate through {reader.n_entries} events ..."
             for events, pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
                 # just invoke the calibration function
-                events = self.calibrator_func(events, **self.get_calibrator_kwargs(self))
+                self.calibrator_func(events, **self.get_calibrator_kwargs(self))
 
                 # manually remove colums that should not be kept
                 if not remove_routes:

--- a/ap/tasks/external.py
+++ b/ap/tasks/external.py
@@ -16,7 +16,7 @@ import luigi
 import law
 
 from ap.tasks.framework.base import AnalysisTask, ConfigTask, DatasetTask, wrapper_factory
-from ap.util import ensure_proxy, wget
+from ap.util import ensure_proxy, wget, safe_div
 
 
 class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
@@ -288,10 +288,7 @@ class CreatePileupWeights(ConfigTask):
                 )
 
             # store them
-            weights[shift] = [
-                (d / m) if m > 0 else 0.0
-                for m, d in zip(mc_profile, data_profile)
-            ]
+            weights[shift] = [safe_div(d, m) for m, d in zip(mc_profile, data_profile)]
             self.publish_message(f"computed pu weights for shift {shift}")
 
         # save it

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -412,13 +412,8 @@ class ShiftTask(ConfigTask):
         # still call super for simplified mro control
         shifts = super().determine_allowed_shifts(config_inst, params)
 
-        # add class level shifts, resolving those of other classes as well
-        for shift in cls.shifts:
-            if isinstance(shift, str):
-                shifts.add(shift)
-            else:
-                # assume shift to be a task class defining shifts on its own
-                shifts |= shift.determine_allowed_shifts(config_inst, params)
+        # add class level shifts
+        shifts |= cls.shifts
 
         return shifts
 

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -526,38 +526,12 @@ class DatasetTask(ShiftTask):
         Returns the number of files that are handled in one branch. Consecutive merging steps are
         not handled yet.
         """
-        merging_info = self.config_inst.get_aux("file_merging")
         n_files = self.dataset_info_inst.n_files
 
         if isinstance(self.file_merging, int):
             # interpret the file_merging attribute as the merging factor itself
             # non-positive numbers mean "merge all in one"
             n_merge = self.file_merging if self.file_merging > 0 else n_files
-        elif self.file_merging in merging_info:
-            # file_merging refers to an entry in merging_info which can be nested as
-            # dataset -> shift -> version
-            n_merge = merging_info[self.file_merging]
-
-            # mapped to dataset?
-            if isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.dataset_inst.name, n_files)
-
-            # mapped to shift?
-            if self.shift_inst and isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.shift_inst.name, n_merge.get("nominal", n_files))
-
-            # mapped to version?
-            if self.version and isinstance(n_merge, dict):
-                n_merge = n_merge.get(self.version, n_files)
-
-            if not isinstance(n_merge, int):
-                raise TypeError(
-                    "the merging factor in the file_merging config must be an integer, but got "
-                    f"'{n_merge}' for dataset {self.dataset_inst}, shift {self.shift_inst} and "
-                    f"version {self.version}",
-                )
-
-            n_merge = n_merge or n_files
         else:
             # no merging at all
             n_merge = 1

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -194,6 +194,8 @@ class SelectorMixin(ConfigTask):
         from ap.selection import Selector
 
         func = Selector.get(selector, copy=copy)
+        if not func.exposed:
+            raise RuntimeError(f"cannot use unexposed selector '{func.__name__}' in {cls.__name__}")
         if update_kwargs:
             func.run_update(**update_kwargs)
 

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -359,12 +359,11 @@ class ProducersMixin(ConfigTask):
     def store_parts(self):
         parts = super().store_parts()
 
-        part = "none"
         if self.producers:
             part = "__".join(self.producers[:5])
             if len(self.producers) > 5:
                 part += f"__{law.util.create_hash(self.producers[5:])}"
-        parts.insert_before("version", "producers", f"prod__{part}")
+            parts.insert_before("version", "producers", f"prod__{part}")
 
         return parts
 
@@ -444,10 +443,9 @@ class MLModelsMixin(ConfigTask):
     def store_parts(self):
         parts = super().store_parts()
 
-        part = "none"
         if self.ml_models:
             part = "__".join(self.ml_models)
-        parts.insert_before("version", "ml_models", f"ml__{part}")
+            parts.insert_before("version", "ml_models", f"ml__{part}")
 
         return parts
 

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -195,7 +195,7 @@ class SelectorMixin(ConfigTask):
 
         func = Selector.get(selector, copy=copy)
         if not func.exposed:
-            raise RuntimeError(f"cannot use unexposed selector '{func.__name__}' in {cls.__name__}")
+            raise RuntimeError(f"cannot use unexposed selector '{selector}' in {cls.__name__}")
         if update_kwargs:
             func.run_update(**update_kwargs)
 

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -194,7 +194,7 @@ class SelectorMixin(ConfigTask):
         from ap.selection import Selector
 
         func = Selector.get(selector, copy=copy)
-        if not func.exposed:
+        if not func.expose:
             raise RuntimeError(f"cannot use unexposed selector '{func.__name__}' in {cls.__name__}")
         if update_kwargs:
             func.run_update(**update_kwargs)

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -194,7 +194,7 @@ class SelectorMixin(ConfigTask):
         from ap.selection import Selector
 
         func = Selector.get(selector, copy=copy)
-        if not func.expose:
+        if not func.exposed:
             raise RuntimeError(f"cannot use unexposed selector '{func.__name__}' in {cls.__name__}")
         if update_kwargs:
             func.run_update(**update_kwargs)

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -27,7 +27,7 @@ class CreateHistograms(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {MergeReducedEvents}
+    shifts = set(MergeReducedEvents.shifts)
 
     def workflow_requires(self):
         reqs = super(CreateHistograms, self).workflow_requires()
@@ -146,7 +146,7 @@ class MergeHistograms(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {CreateHistograms}
+    shifts = set(CreateHistograms.shifts)
 
     # in each step, merge 10 into 1
     merge_factor = 10

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -154,6 +154,8 @@ class MergeHistograms(
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # tell ForestMerge to not cache the internal merging structure by default,
+        # (this is enabled in merge_workflow_requires)
         self._cache_forest = False
 
     def create_branch_map(self):

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -165,9 +165,8 @@ class MergeHistograms(
     def merge_workflow_requires(self):
         req = CreateHistograms.req(self, _exclude=["branches"])
 
-        # if the reduced merging factor is present, allow the forest to be cached
-        if req.reduced_file_merging >= 1:
-            self._cache_forest = True
+        # if the merging stats exist, allow the forest to be cached
+        self._cache_forest = req.merging_stats_exist
 
         return req
 

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -29,7 +29,7 @@ class CreateHistograms(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = set(MergeReducedEvents.shifts)
+    shifts = MergeReducedEvents.shifts | ProduceColumns.shifts
 
     def workflow_requires(self):
         reqs = super(CreateHistograms, self).workflow_requires()

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -85,10 +85,10 @@ class CreateHistograms(
             msg = f"iterate through {reader.n_entries} events ..."
             for (events, *columns), pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
                 # add additional columns
-                events = update_ak_array(events, *columns)
+                update_ak_array(events, *columns)
 
                 # add aliases
-                events = add_ak_aliases(events, aliases, remove_src=True)
+                add_ak_aliases(events, aliases, remove_src=True)
 
                 # build the full event weight
                 weight = ak.Array(np.ones(len(events)))

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -11,13 +11,13 @@ from ap.tasks.framework.mixins import (
     CalibratorsSelectorMixin, ProducersMixin, VariablesMixin, ShiftSourcesMixin,
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
-from ap.tasks.reduction import ReduceEvents
+from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from ap.tasks.production import ProduceColumns
 from ap.util import ensure_proxy, dev_sandbox
 
 
 class CreateHistograms(
-    DatasetTask,
+    MergeReducedEventsUser,
     ProducersMixin,
     CalibratorsSelectorMixin,
     VariablesMixin,
@@ -27,22 +27,24 @@ class CreateHistograms(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {ReduceEvents}
+    shifts = {MergeReducedEvents}
 
     def workflow_requires(self):
         reqs = super(CreateHistograms, self).workflow_requires()
-        if not self.pilot:
-            reqs["events"] = ReduceEvents.req(self)
-            if self.producers:
-                reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
+        reqs["events"] = MergeReducedEvents.req(self)
+        if not self.pilot and self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
         return reqs
 
     def requires(self):
-        reqs = {"events": ReduceEvents.req(self)}
+        reqs = {"events": MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"})}
         if self.producers:
             reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
         return reqs
 
+    @MergeReducedEventsUser.maybe_dummy
     def output(self):
         return self.local_target(f"histograms_vars_{self.variables_repr}_{self.branch}.pickle")
 
@@ -71,7 +73,7 @@ class CreateHistograms(
         aliases = self.shift_inst.x("column_aliases", {})
 
         # iterate over chunks of events and diffs
-        files = [inputs["events"].path]
+        files = [inputs["events"]["collection"][0].path]
         if self.producers:
             files.extend([inp.path for inp in inputs["producers"]])
         with ChunkedReader(
@@ -149,12 +151,23 @@ class MergeHistograms(
     # in each step, merge 10 into 1
     merge_factor = 10
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._cache_forest = False
+
     def create_branch_map(self):
         # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
         return law.tasks.ForestMerge.create_branch_map(self)
 
     def merge_workflow_requires(self):
-        return CreateHistograms.req(self, _exclude=["branches"])
+        req = CreateHistograms.req(self, _exclude=["branches"])
+
+        # if the reduced merging factor is present, allow the forest to be cached
+        if req.reduced_file_merging >= 1:
+            self._cache_forest = True
+
+        return req
 
     def merge_requires(self, start_leaf, end_leaf):
         return [CreateHistograms.req(self, branch=i) for i in range(start_leaf, end_leaf)]

--- a/ap/tasks/ml.py
+++ b/ap/tasks/ml.py
@@ -1,0 +1,381 @@
+# coding: utf-8
+
+"""
+Tasks related to ML workflows.
+"""
+
+import law
+import luigi
+
+from ap.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
+from ap.tasks.framework.mixins import CalibratorsSelectorMixin, ProducersMixin, MLModelMixin
+from ap.tasks.framework.remote import HTCondorWorkflow
+from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
+from ap.tasks.production import ProduceColumns
+from ap.util import dev_sandbox, safe_div
+
+
+class PrepareMLEvents(
+    MergeReducedEventsUser,
+    MLModelMixin,
+    ProducersMixin,
+    CalibratorsSelectorMixin,
+    law.LocalWorkflow,
+    HTCondorWorkflow,
+):
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # complain for cases where this task is not needed
+        if not self.events_used_in_training(self.dataset_inst, self.shift_inst):
+            raise Exception(
+                f"for ML model '{self.ml_model_inst.name}', the dataset '{self.dataset_inst.name}' "
+                f"with shift '{self.shift_inst.name}' is not intended to be run by "
+                f"{self.__class__.__name__}",
+            )
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
+        if not self.pilot and self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
+        return reqs
+
+    def requires(self):
+        reqs = {"events": MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"})}
+        if self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+        return reqs
+
+    @MergeReducedEventsUser.maybe_dummy
+    def output(self):
+        k = self.ml_model_inst.folds
+        return law.SiblingFileCollection([
+            self.local_target(f"mlevents_fold{f}of{k}_{self.branch}.parquet")
+            for f in range(k)
+        ])
+
+    @law.decorator.safe_output
+    @law.decorator.localize
+    def run(self):
+        from ap.columnar_util import (
+            ChunkedReader, sorted_ak_to_parquet, update_ak_array, get_ak_routes, remove_ak_column,
+        )
+
+        # prepare inputs and outputs
+        inputs = self.input()
+        outputs = self.output()
+        output_chunks = [{} for _ in range(self.ml_model_inst.folds)]
+
+        # create a temp dir for saving intermediate files
+        tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
+        tmp_dir.touch()
+
+        # define nano columns that should be loaded and those that should be kept
+        keep_columns = self.ml_model_inst.uses
+        load_columns = keep_columns | {"deterministic_seed"}  # noqa
+        remove_routes = None
+
+        # stats for logging
+        n_events = 0
+        n_fold_events = self.ml_model_inst.folds * [0]
+
+        # iterate over chunks of events and columns
+        files = [inputs["events"]["collection"][0].path]
+        if self.producers:
+            files.extend([inp.path for inp in inputs["producers"]])
+        with ChunkedReader(
+            files,
+            source_type=len(files) * ["awkward_parquet"],
+            # TODO: not working yet since parquet columns are nested
+            # open_options=[{"columns": load_columns}] + (len(files) - 1) * [None],
+        ) as reader:
+            msg = f"iterate through {reader.n_entries} events ..."
+            for (events, *columns), pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
+                # add additional columns
+                update_ak_array(events, *columns)
+                n_events += len(events)
+
+                # generate fold indices
+                indices = events.deterministic_seed % self.ml_model_inst.folds
+
+                # manually remove colums that should not be kept
+                if not remove_routes:
+                    remove_routes = {
+                        route
+                        for route in get_ak_routes(events)
+                        if not law.util.multi_match(route.column, keep_columns)
+                    }
+                for route in remove_routes:
+                    events = remove_ak_column(events, route)
+
+                # loop over folds, use indices to generate masks and project into files
+                for f in range(self.ml_model_inst.folds):
+                    fold_events = events[indices == f]
+                    n_fold_events[f] += len(fold_events)
+
+                    # save as parquet via a thread in the same pool
+                    chunk = tmp_dir.child(f"file_{f}_{pos.index}.parquet", type="f")
+                    output_chunks[f][pos.index] = chunk
+                    reader.add_task(sorted_ak_to_parquet, (fold_events, chunk.path))
+
+        # merge output files of all folds
+        for _output_chunks, output in zip(output_chunks, outputs.targets):
+            sorted_chunks = [_output_chunks[key] for key in sorted(_output_chunks)]
+            law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+
+        # some logs
+        self.publish_message(f"total events: {n_events}")
+        for f, n in enumerate(n_fold_events):
+            r = 100 * safe_div(n, n_events)
+            self.publish_message(f"partition {' ' if f < 10 else ''}{f}: {n} ({r:.2f}%)")
+
+
+PrepareMLEventsWrapper = wrapper_factory(
+    base_cls=AnalysisTask,
+    require_cls=PrepareMLEvents,
+    enable=["configs", "skip_configs", "shifts", "skip_shifts", "datasets", "skip_datasets"],
+)
+
+
+class MergeMLEvents(
+    DatasetTask,
+    MLModelMixin,
+    ProducersMixin,
+    CalibratorsSelectorMixin,
+    law.tasks.ForestMerge,
+    HTCondorWorkflow,
+):
+
+    fold = luigi.IntParameter(
+        default=0,
+        description="the fold index of the prepared ML events to use; must be compatible with the "
+        "number of folds defined in the ML model; default: 0",
+    )
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+
+    # disable the shift parameter
+    shift = None
+    effective_shift = None
+    allow_empty_shift = True
+
+    # in each step, merge 10 into 1
+    merge_factor = 10
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not (0 <= self.fold < self.ml_model_inst.folds):
+            raise ValueError(
+                "the fold index is incompatible with the number of folds "
+                f"({self.ml_model_inst.fold}) for the ML model '{self.ml_model}'",
+            )
+
+        # tell ForestMerge to not cache the internal merging structure by default,
+        # (this is enabled in merge_workflow_requires)
+        self._cache_forest = False
+
+    def create_branch_map(self):
+        # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
+        return law.tasks.ForestMerge.create_branch_map(self)
+
+    def merge_workflow_requires(self):
+        req = PrepareMLEvents.req(self, _exclude={"branches"})
+
+        # if the merging stats exist, allow the forest to be cached
+        self._cache_forest = req.merging_stats_exist
+
+        return req
+
+    def merge_requires(self, start_leaf, end_leaf):
+        return [PrepareMLEvents.req(self, branch=i) for i in range(start_leaf, end_leaf)]
+
+    def trace_merge_inputs(self, inputs):
+        return super().trace_merge_inputs([inp[self.fold] for inp in inputs])
+
+    def merge_output(self):
+        k = self.ml_model_inst.folds
+        return self.local_target(f"mlevents_f{self.fold}of{k}.parquet")
+
+    def merge(self, inputs, output):
+        law.pyarrow.merge_parquet_task(self, inputs, output)
+
+
+MergeMLEventsWrapper = wrapper_factory(
+    base_cls=AnalysisTask,
+    require_cls=MergeMLEvents,
+    enable=["configs", "skip_configs", "datasets", "skip_datasets"],
+)
+
+
+class MLTraining(MLModelMixin, ProducersMixin, CalibratorsSelectorMixin):
+
+    fold = luigi.IntParameter(
+        default=0,
+        description="the fold index of the prepared ML events to _skip_; must be compatible with "
+        "the number of folds defined in the ML model; default: 0",
+    )
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_ml_tf.sh")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not (0 <= self.fold < self.ml_model_inst.folds):
+            raise ValueError(
+                "the fold index is incompatible with the number of folds "
+                f"({self.ml_model_inst.fold}) for the ML model '{self.ml_model}'",
+            )
+
+    def requires(self):
+        return {
+            dataset_inst.name: [
+                MergeMLEvents.req(self, dataset=dataset_inst.name, fold=f)
+                for f in range(self.ml_model_inst.folds)
+                if f != self.fold
+            ]
+            for dataset_inst in self.ml_model_inst.datasets
+        }
+
+    def output(self):
+        return law.util.map_struct(
+            (lambda func_args: func_args(self.local_target)),
+            self.ml_model_inst.define_output(self),
+        )
+
+    @law.decorator.safe_output
+    @law.decorator.localize
+    def run(self):
+        # prepare inputs and outputs
+        inputs = self.input()
+        outputs = self.output()
+
+        # call the training function
+        self.ml_model_inst.train(self, inputs, outputs)
+
+
+class MLEvaluation(
+    MergeReducedEventsUser,
+    MLModelMixin,
+    ProducersMixin,
+    CalibratorsSelectorMixin,
+    law.LocalWorkflow,
+    HTCondorWorkflow,
+):
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_ml_tf.sh")
+
+    shifts = MergeReducedEvents.shifts | ProduceColumns.shifts
+
+    def workflow_requires(self):
+        reqs = super(MLEvaluation, self).workflow_requires()
+
+        reqs["models"] = [MLTraining.req(self, fold=f) for f in range(self.ml_model_inst.folds)]
+
+        reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
+        if not self.pilot and self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
+        return reqs
+
+    def requires(self):
+        reqs = {"models": [MLTraining.req(self, fold=f) for f in range(self.ml_model_inst.folds)]}
+
+        reqs["events"] = MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"})
+        if self.producers:
+            reqs["producers"] = [ProduceColumns.req(self, producer=p) for p in self.producers]
+
+        return reqs
+
+    @MergeReducedEventsUser.maybe_dummy
+    def output(self):
+        return self.local_target(f"mlcols_{self.branch}.pickle")
+
+    @law.decorator.safe_output
+    @law.decorator.localize
+    def run(self):
+        from ap.columnar_util import (
+            ChunkedReader, sorted_ak_to_parquet, update_ak_array, add_ak_aliases, get_ak_routes,
+            remove_ak_column,
+        )
+
+        # prepare inputs and outputs
+        inputs = self.input()
+        output = self.output()
+        output_chunks = {}
+
+        # create a temp dir for saving intermediate files
+        tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
+        tmp_dir.touch()
+
+        # open all model files
+        models = [self.ml_model_inst.open_model(inp) for inp in inputs["models"]]
+
+        # get shift dependent aliases
+        aliases = self.shift_inst.x("column_aliases", {})
+
+        # check once if the events were used during trainig
+        events_used_in_training = self.events_used_in_training(self.dataset_inst, self.shift_inst)
+
+        # define nano columns that should be loaded and those that should be kept
+        load_columns = self.ml_model_inst.uses | {"deterministic_seed"}  # noqa
+        keep_columns = self.ml_model_inst.produces
+        remove_routes = None
+
+        # iterate over chunks of events and diffs
+        files = [inputs["events"]["collection"][0].path]
+        if self.producers:
+            files.extend([inp.path for inp in inputs["producers"]])
+        with ChunkedReader(
+            files,
+            source_type=len(files) * ["awkward_parquet"],
+            # TODO: not working yet since parquet columns are nested
+            # open_options=[{"columns": load_columns}] + (len(files) - 1) * [None],
+        ) as reader:
+            msg = f"iterate through {reader.n_entries} events ..."
+            for (events, *columns), pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
+                # add additional columns
+                update_ak_array(events, *columns)
+
+                # add aliases
+                add_ak_aliases(events, aliases, remove_src=True)
+
+                # evaluate the model
+                self.ml_model_inst.evaluate(
+                    self,
+                    models,
+                    events,
+                    events_used_in_training=events_used_in_training,
+                )
+
+                # manually remove colums that should not be kept
+                if not remove_routes:
+                    remove_routes = {
+                        route
+                        for route in get_ak_routes(events)
+                        if not law.util.multi_match(route.column, keep_columns)
+                    }
+                for route in remove_routes:
+                    events = remove_ak_column(events, route)
+
+                # save as parquet via a thread in the same pool
+                chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
+                output_chunks[pos.index] = chunk
+                reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+
+        # merge output files
+        sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
+        law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+
+
+MLEvaluationWrapper = wrapper_factory(
+    base_cls=AnalysisTask,
+    require_cls=MLEvaluation,
+    enable=["configs", "skip_configs", "shifts", "skip_shifts", "datasets", "skip_datasets"],
+)

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -45,7 +45,7 @@ class PlotVariables(
 
     sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
-    shifts = {MergeHistograms}
+    shifts = set(MergeHistograms.shifts)
 
     def create_branch_map(self):
         return [

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -10,8 +10,8 @@ import law
 
 from ap.tasks.framework.base import ShiftTask
 from ap.tasks.framework.mixins import (
-    CalibratorsSelectorMixin, ProducersMixin, PlotMixin, CategoriesMixin, VariablesMixin,
-    DatasetsProcessesMixin, ShiftSourcesMixin,
+    CalibratorsSelectorMixin, ProducersMixin, MLModelsMixin, PlotMixin, CategoriesMixin,
+    VariablesMixin, DatasetsProcessesMixin, ShiftSourcesMixin,
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
@@ -36,6 +36,7 @@ class ProcessPlotBase(
 
 class PlotVariables(
     ShiftTask,
+    MLModelsMixin,
     ProducersMixin,
     CalibratorsSelectorMixin,
     ProcessPlotBase,
@@ -252,6 +253,7 @@ class PlotVariables(
 
 
 class PlotShiftedVariables(
+    MLModelsMixin,
     ProducersMixin,
     CalibratorsSelectorMixin,
     ProcessPlotBase,

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -23,7 +23,7 @@ class ProduceColumns(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {MergeReducedEvents}
+    shifts = set(MergeReducedEvents.shifts)
 
     update_producer = True
 

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -10,7 +10,7 @@ from ap.tasks.framework.base import AnalysisTask, wrapper_factory
 from ap.tasks.framework.mixins import CalibratorsSelectorMixin, ProducerMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
-from ap.util import ensure_proxy, dev_sandbox
+from ap.util import dev_sandbox
 
 
 class ProduceColumns(
@@ -47,7 +47,6 @@ class ProduceColumns(
 
     @law.decorator.safe_output
     @law.decorator.localize
-    @ensure_proxy
     def run(self):
         from ap.columnar_util import (
             ChunkedReader, mandatory_coffea_columns, get_ak_routes, remove_ak_column,

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -83,7 +83,7 @@ class ProduceColumns(
             msg = f"iterate through {reader.n_entries} events ..."
             for events, pos in self.iter_progress(reader, reader.n_chunks, msg=msg):
                 # invoke the producer
-                events = self.producer_func(events, **self.get_producer_kwargs(self))
+                self.producer_func(events, **self.get_producer_kwargs(self))
 
                 # manually remove colums that should not be kept
                 if not remove_routes:

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -15,7 +15,7 @@ from ap.tasks.framework.mixins import CalibratorsSelectorMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.external import GetDatasetLFNs
 from ap.tasks.selection import CalibrateEvents, SelectEvents
-from ap.util import ensure_proxy, dev_sandbox
+from ap.util import ensure_proxy, dev_sandbox, safe_div
 
 
 class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTCondorWorkflow):
@@ -134,9 +134,8 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
 
         # some logs
-        save_div = lambda x, y: (x / y) if y else 0.0
         self.publish_message(
-            f"reduced {n_all} to {n_reduced} events ({save_div(n_reduced, n_all) * 100:.2f}%)",
+            f"reduced {n_all} to {n_reduced} events ({safe_div(n_reduced, n_all) * 100:.2f}%)",
         )
 
         # merge output files
@@ -267,7 +266,7 @@ class MergeReducedEventsUser(DatasetTask):
             # check of the merging stats is present and of so, set the cached file merging value
             output = MergeReductionStats.req(self).output()
             if output.exists():
-                self._cached_file_merging = output.load(formatter="json")["merge_factor"]
+                self._cached_file_merging = 1  # output.load(formatter="json")["merge_factor"]
                 self._cache_branches = True
 
         return self._cached_file_merging

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -266,7 +266,7 @@ class MergeReducedEventsUser(DatasetTask):
             # check of the merging stats is present and of so, set the cached file merging value
             output = MergeReductionStats.req(self).output()
             if output.exists():
-                self._cached_file_merging = 1  # output.load(formatter="json")["merge_factor"]
+                self._cached_file_merging = output.load(formatter="json")["merge_factor"]
                 self._cache_branches = True
 
         return self._cached_file_merging

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -260,10 +260,6 @@ class MergeReducedEventsUser(DatasetTask):
         """
         Needed by DatasetTask to define the default branch map.
         """
-        return self.reduced_file_merging
-
-    @property
-    def reduced_file_merging(self):
         if self._cached_file_merging < 0:
             # reset the forest in case this is a forest ForestMerge task
             self._forest_built = False
@@ -276,6 +272,10 @@ class MergeReducedEventsUser(DatasetTask):
 
         return self._cached_file_merging
 
+    @property
+    def merging_stats_exist(self):
+        return self.file_merging >= 1
+
     def reduced_dummy_output(self):
         # dummy output to be returned in case the merging stats are not present yet
         return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
@@ -287,7 +287,7 @@ class MergeReducedEventsUser(DatasetTask):
         @functools.wraps(func)
         def wrapper(self):
             # when the merging stats do not exist yet, return a dummy target
-            if self.reduced_file_merging < 1:
+            if not self.merging_stats_exist:
                 return self.reduced_dummy_output()
 
             # otherwise, bind the wrapped function and call it

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -22,7 +22,7 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {CalibrateEvents, SelectEvents}
+    shifts = CalibrateEvents.shifts | SelectEvents.shifts
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
@@ -166,7 +166,7 @@ class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
         description="the maximum file size of merged files; default unit is MB; default: '500MB'",
     )
 
-    shifts = {ReduceEvents}
+    shifts = set(ReduceEvents.shifts)
 
     def requires(self):
         return ReduceEvents.req(self, branches=((0, self.n_inputs),))
@@ -300,7 +300,7 @@ class MergeReducedEvents(MergeReducedEventsUser, CalibratorsSelectorMixin, law.t
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {ReduceEvents, MergeReductionStats}
+    shifts = ReduceEvents.shifts | MergeReductionStats.shifts
 
     def create_branch_map(self):
         # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -98,10 +98,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 # to filter events and objects
 
                 # add the calibrated diffs and potentially new columns
-                events = update_ak_array(events, *diffs)
+                update_ak_array(events, *diffs)
 
                 # add aliases
-                events = add_ak_aliases(events, aliases, remove_src=True)
+                add_ak_aliases(events, aliases, remove_src=True)
 
                 # apply the event mask
                 n_all += len(events)

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -248,12 +248,18 @@ class MergeReducedEventsUser(DatasetTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cached value of the file_merging until it's positive and the branch map is stable
+        # cached value of the file_merging until it's positive
         self._cached_file_merging = -1
+
+        # in case this is a workflow, do not cache branches by default
+        # (this is enabled in reduced_file_merging once positive)
         self._cache_branches = False
 
     @property
     def file_merging(self):
+        """
+        Needed by DatasetTask to define the default branch map.
+        """
         return self.reduced_file_merging
 
     @property
@@ -271,10 +277,13 @@ class MergeReducedEventsUser(DatasetTask):
         return self._cached_file_merging
 
     def reduced_dummy_output(self):
+        # dummy output to be returned in case the merging stats are not present yet
         return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
 
     @classmethod
     def maybe_dummy(cls, func):
+        # meant to wrap output methods of tasks depending on merging stats
+        # to inject a dummy output in case the status are not there yet
         @functools.wraps(func)
         def wrapper(self):
             # when the merging stats do not exist yet, return a dummy target

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -4,9 +4,11 @@
 Tasks related to reducing events for use on further tasks.
 """
 
+import functools
 from collections import OrderedDict
 
 import law
+import luigi
 
 from ap.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from ap.tasks.framework.mixins import CalibratorsSelectorMixin
@@ -68,6 +70,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
         load_columns_nano = [Route.check(column).nano_column for column in load_columns]
         remove_routes = None
 
+        # event counters
+        n_all = 0
+        n_reduced = 0
+
         # let the lfn_task prepare the nano file (basically determine a good pfn)
         [(lfn_index, input_file)] = lfn_task.iter_nano_files(self)
 
@@ -98,8 +104,10 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 events = add_ak_aliases(events, aliases, remove_src=True)
 
                 # apply the event mask
+                n_all += len(events)
                 event_mask = sel.event if "event" in sel.fields else Ellipsis
                 events = events[event_mask]
+                n_reduced += len(events)
 
                 # apply all object masks whose names are present
                 # TODO: this should not be done automagically based on names as there might be
@@ -125,6 +133,12 @@ class ReduceEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 output_chunks[pos.index] = chunk
                 reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
 
+        # some logs
+        save_div = lambda x, y: (x / y) if y else 0.0
+        self.publish_message(
+            f"reduced {n_all} to {n_reduced} events ({save_div(n_reduced, n_all) * 100:.2f}%)",
+        )
+
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
@@ -139,8 +153,14 @@ ReduceEventsWrapper = wrapper_factory(
 
 class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
 
+    n_inputs = luigi.IntParameter(
+        default=2,
+        significant=True,
+        description="minimal number of input files for sufficient statistics to infer merging "
+        "factors; default: 2",  # TODO: update once going to production
+    )
     merged_size = law.BytesParameter(
-        default=500.0,
+        default=1024.0,
         unit="MB",
         significant=False,
         description="the maximum file size of merged files; default unit is MB; default: '500MB'",
@@ -149,10 +169,10 @@ class MergeReductionStats(DatasetTask, CalibratorsSelectorMixin):
     shifts = {ReduceEvents}
 
     def requires(self):
-        return ReduceEvents.req(self)
+        return ReduceEvents.req(self, branches=((0, self.n_inputs),))
 
     def output(self):
-        return self.local_target("stats.json")
+        return self.local_target(f"stats_n{self.n_inputs}.json")
 
     @law.decorator.safe_output
     def run(self):
@@ -220,28 +240,82 @@ MergeReductionStatsWrapper = wrapper_factory(
 )
 
 
-class MergeReducedEvents(DatasetTask, CalibratorsSelectorMixin, law.tasks.ForestMerge, HTCondorWorkflow):
-
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
-
-    shifts = {SelectEvents}
+class MergeReducedEventsUser(DatasetTask):
 
     # recursively merge 8 files into one
     merge_factor = 8
 
-    # the key of the config that defines the merging in the branch map of DatasetTask
-    file_merging = "after_reduction"
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # cached value of the file_merging until it's positive and the branch map is stable
+        self._cached_file_merging = -1
+        self._cache_branches = False
+
+    @property
+    def file_merging(self):
+        return self.reduced_file_merging
+
+    @property
+    def reduced_file_merging(self):
+        if self._cached_file_merging < 0:
+            # reset the forest in case this is a forest ForestMerge task
+            self._forest_built = False
+
+            # check of the merging stats is present and of so, set the cached file merging value
+            output = MergeReductionStats.req(self).output()
+            if output.exists():
+                self._cached_file_merging = output.load(formatter="json")["merge_factor"]
+                self._cache_branches = True
+
+        return self._cached_file_merging
+
+    def reduced_dummy_output(self):
+        return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
+
+    @classmethod
+    def maybe_dummy(cls, func):
+        @functools.wraps(func)
+        def wrapper(self):
+            # when the merging stats do not exist yet, return a dummy target
+            if self.reduced_file_merging < 1:
+                return self.reduced_dummy_output()
+
+            # otherwise, bind the wrapped function and call it
+            return func.__get__(self, self.__class__)()
+
+        return wrapper
+
+
+class MergeReducedEvents(MergeReducedEventsUser, CalibratorsSelectorMixin, law.tasks.ForestMerge, HTCondorWorkflow):
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+
+    shifts = {ReduceEvents, MergeReductionStats}
 
     def create_branch_map(self):
         # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
         return law.tasks.ForestMerge.create_branch_map(self)
 
     def merge_workflow_requires(self):
-        return ReduceEvents.req(self, _exclude={"branches"})
+        return {
+            "stats": MergeReductionStats.req(self),
+            "events": ReduceEvents.req(self, _exclude={"branches"}),
+        }
 
     def merge_requires(self, start_branch, end_branch):
-        return [ReduceEvents.req(self, branch=b) for b in range(start_branch, end_branch)]
+        return {
+            "stats": MergeReductionStats.req(self),
+            "events": [ReduceEvents.req(self, branch=b) for b in range(start_branch, end_branch)],
+        }
 
+    def trace_merge_workflow_inputs(self, inputs):
+        return super().trace_merge_workflow_inputs(inputs["events"])
+
+    def trace_merge_inputs(self, inputs):
+        return super().trace_merge_inputs(inputs["events"])
+
+    @MergeReducedEventsUser.maybe_dummy
     def merge_output(self):
         # use the branch_map defined in DatasetTask to compute the number of files after merging
         n_merged = len(DatasetTask.create_branch_map(self))

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -20,7 +20,7 @@ class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = {CalibrateEvents}
+    shifts = set(CalibrateEvents.shifts)
 
     update_selector = True
 
@@ -178,7 +178,7 @@ SelectEventsWrapper = wrapper_factory(
 
 class MergeSelectionStats(DatasetTask, CalibratorsSelectorMixin, law.tasks.ForestMerge):
 
-    shifts = {SelectEvents}
+    shifts = set(SelectEvents.shifts)
 
     # recursively merge 20 files into one
     merge_factor = 20

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -13,7 +13,7 @@ from ap.tasks.framework.mixins import CalibratorsSelectorMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.external import GetDatasetLFNs
 from ap.tasks.calibration import CalibrateEvents
-from ap.util import ensure_proxy, dev_sandbox
+from ap.util import ensure_proxy, dev_sandbox, safe_div
 
 
 class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTCondorWorkflow):
@@ -158,9 +158,8 @@ class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
         outputs["stats"].dump(stats, formatter="json")
 
         # print some stats
-        save_div = lambda x, y: (x / y) if y else 0.0
-        eff = save_div(stats["n_events_selected"], stats["n_events"])
-        eff_weighted = save_div(stats["sum_mc_weight_selected"], stats["sum_mc_weight"])
+        eff = safe_div(stats["n_events_selected"], stats["n_events"])
+        eff_weighted = safe_div(stats["sum_mc_weight_selected"], stats["sum_mc_weight"])
         self.publish_message(f"all events         : {int(stats['n_events'])}")
         self.publish_message(f"sel. events        : {int(stats['n_events_selected'])}")
         self.publish_message(f"efficiency         : {eff:.4f}")

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -115,22 +115,13 @@ class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTC
                 # book-keeping of stats
 
                 # apply the calibrated diffs
-                events = update_ak_array(events, *diffs)
+                update_ak_array(events, *diffs)
 
                 # add aliases
-                events = add_ak_aliases(events, aliases)
+                add_ak_aliases(events, aliases)
 
-                # invoke the selection function and parse the result which can be a single
-                # SelectionResult or a 2-tuple (SelectionResult, events)
-                obj = self.selector_func(events, stats, **self.get_selector_kwargs(self))
-                if not isinstance(obj, tuple):
-                    results = obj
-                elif len(obj) == 2:
-                    results, events = obj
-                else:
-                    raise ValueError(
-                        f"cannot interpret return value '{obj}' of selector {self.selector}",
-                    )
+                # invoke the selection function
+                results = self.selector_func(events, stats, **self.get_selector_kwargs(self))
 
                 # save results as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")

--- a/ap/util.py
+++ b/ap/util.py
@@ -379,7 +379,7 @@ def dev_sandbox(sandbox: str) -> str:
     return law.Sandbox.join_key(_type, dev_path)
 
 
-def freeze(cont):
+def freeze(cont: Any) -> Any:
     """Constructs an immutable version of a native Python container.
 
     Recursively replaces all mutable containers (``dict``, ``list``, ``set``) encountered within
@@ -396,7 +396,7 @@ def freeze(cont):
     return cont
 
 
-def memoize(f):
+def memoize(f: Callable) -> Callable:
     """
     Function decorator that implements memoization. Function results are cached on
     first call and returned from cache on every subsequent call with the same arguments.

--- a/law.cfg
+++ b/law.cfg
@@ -11,15 +11,17 @@ ap.tasks.calibration
 ap.tasks.selection
 ap.tasks.reduction
 ap.tasks.production
+ap.tasks.ml
 ap.tasks.histograms
 ap.tasks.plotting
 
 
 [analysis]
 
-production_modules: ap.production.{processes,features,pileup,normalization,weights}
-calibration_modules: ap.calibration.{test,jets,seeds}
+production_modules: ap.production.{processes,features,pileup,normalization,seeds,weights}
+calibration_modules: ap.calibration.{test,jets}
 selection_modules: ap.selection.test
+ml_modules: ap.ml.test
 
 
 [job]

--- a/law.cfg
+++ b/law.cfg
@@ -123,5 +123,6 @@ worker-disconnect-delay: 30
 ping_interval: 20
 wait_interval: 20
 check_unfulfilled_deps: False
+cache_task_completion: True
 keep_alive: True
 force_multiprocessing: False

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,0 +1,5 @@
+# version 1
+
+tensorflow==2.6.*
+pyarrow==6.0.*
+awkward==1.8.*

--- a/sandboxes/venv_ml_tf.sh
+++ b/sandboxes/venv_ml_tf.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Script that sets up a virtual env in $AP_VENV_PATH.
+# For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
+
+action() {
+    local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
+
+    # set variables and source the generic venv setup
+    export AP_VENV_NAME="$( basename "${this_file%.sh}" )"
+    export AP_VENV_REQUIREMENTS="$this_dir/ml_tf.txt"
+
+    source "$this_dir/_setup_venv.sh" "$@"
+}
+action "$@"

--- a/sandboxes/venv_ml_tf_dev.sh
+++ b/sandboxes/venv_ml_tf_dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Script that sets up a virtual env in $AP_VENV_PATH.
+# For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
+
+action() {
+    local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
+
+    # set variables and source the generic venv setup
+    export AP_VENV_NAME="$( basename "${this_file%.sh}" )"
+    export AP_VENV_REQUIREMENTS="$this_dir/ml_tf.txt,$this_dir/dev.txt"
+
+    source "$this_dir/_setup_venv.sh" "$@"
+}
+action "$@"


### PR DESCRIPTION
This PR adds all objects needed to perform ML trainings and evaluations. This required a few generalizations of existing, non-ML-related code:

- Existing producers/calibrators/selectors should be called while bound to the instance, e.g. `def my_producer(events, **kwargs)` becomes `def my_producer(self, events, **kwargs)`. This is far more consistent and provides access to the instance itself.
- `deterministic_seeds` is now a producer as it should be (was a calibrator before). Also, it's fixed for use with real data.
- Some minor code cleanup here and there. Pardon me :)

The new ML-related changes are:

- Added a `venv_ml_tf[_dev]` sandbox. Python 3.6 forces us to use TF 2.6.
- Added a new `MLModel` interface with is a super basic layer that defines model training and evaluation, plus some connections to the task and the usual `uses/produces` columns.
- A dummy model that implements the interface for testing.
- Two new mixins: `MLModelMixin` and `MLModelsMixin`. This fits nicely into the existing mixin-logic and is mostly trivial.
- Four new tasks that perform the workflow and that all inherit from `MLModelMixin` (singular):
  - `PrepareMLEvents`: Divides events into folds for k-fold cross validation and writes input features used by the model.
  - `MergeMLEvents`: Merges the output of `PrepareMLEvents` per fold for faster training loops.
  - `MLTraining`: The actual training task producing models.
  - `MLEvaluation`: Performs the evaluation of one model for events seen and unseen during training (k-fold x-validation).
- `CreateHistograms` and all tasks downstream inherit from `MLModelsMixin` (plural) now. If requested, they triggers the training / evaluation of multiple ML models upstream to write their results into histograms.

Closes #17.

The WIP label is due to the dependence on #54 which needs to be merged first before the review makes sense.