### PR TITLE
Add and use SelectorStepsMixin

### DIFF
--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -10,7 +10,7 @@ import law
 
 from ap.tasks.framework.base import DatasetTask
 from ap.tasks.framework.mixins import (
-    CalibratorsSelectorMixin, ProducersMixin, VariablesMixin, ShiftSourcesMixin,
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, VariablesMixin, ShiftSourcesMixin,
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
@@ -21,7 +21,8 @@ from ap.util import ensure_proxy, dev_sandbox
 class CreateHistograms(
     MergeReducedEventsUser,
     ProducersMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     VariablesMixin,
     law.LocalWorkflow,
     HTCondorWorkflow,
@@ -163,7 +164,8 @@ class CreateHistograms(
 class MergeHistograms(
     DatasetTask,
     ProducersMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     VariablesMixin,
     law.tasks.ForestMerge,
     HTCondorWorkflow,
@@ -221,7 +223,8 @@ class MergeHistograms(
 class MergeShiftedHistograms(
     DatasetTask,
     ProducersMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     VariablesMixin,
     ShiftSourcesMixin,
     law.LocalWorkflow,

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -10,8 +10,8 @@ import law
 
 from ap.tasks.framework.base import ShiftTask
 from ap.tasks.framework.mixins import (
-    CalibratorsSelectorMixin, ProducersMixin, PlotMixin, CategoriesMixin, VariablesMixin,
-    DatasetsProcessesMixin, ShiftSourcesMixin,
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, PlotMixin, CategoriesMixin,
+    VariablesMixin, DatasetsProcessesMixin, ShiftSourcesMixin,
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
@@ -37,7 +37,8 @@ class ProcessPlotBase(
 class PlotVariables(
     ShiftTask,
     ProducersMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     ProcessPlotBase,
     law.LocalWorkflow,
     HTCondorWorkflow,
@@ -253,7 +254,8 @@ class PlotVariables(
 
 class PlotShiftedVariables(
     ProducersMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     ProcessPlotBase,
     ShiftSourcesMixin,
     law.LocalWorkflow,

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -7,7 +7,7 @@ Tasks related to producing new columns.
 import law
 
 from ap.tasks.framework.base import AnalysisTask, wrapper_factory
-from ap.tasks.framework.mixins import CalibratorsSelectorMixin, ProducerMixin
+from ap.tasks.framework.mixins import CalibratorsMixin, SelectorStepsMixin, ProducerMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from ap.util import ensure_proxy, dev_sandbox
@@ -16,7 +16,8 @@ from ap.util import ensure_proxy, dev_sandbox
 class ProduceColumns(
     MergeReducedEventsUser,
     ProducerMixin,
-    CalibratorsSelectorMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     law.LocalWorkflow,
     HTCondorWorkflow,
 ):

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -9,14 +9,14 @@ from collections import defaultdict
 import law
 
 from ap.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
-from ap.tasks.framework.mixins import CalibratorsSelectorMixin
+from ap.tasks.framework.mixins import CalibratorsMixin, SelectorMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.external import GetDatasetLFNs
 from ap.tasks.calibration import CalibrateEvents
 from ap.util import ensure_proxy, dev_sandbox
 
 
-class SelectEvents(DatasetTask, CalibratorsSelectorMixin, law.LocalWorkflow, HTCondorWorkflow):
+class SelectEvents(DatasetTask, SelectorMixin, CalibratorsMixin, law.LocalWorkflow, HTCondorWorkflow):
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
@@ -176,7 +176,7 @@ SelectEventsWrapper = wrapper_factory(
 )
 
 
-class MergeSelectionStats(DatasetTask, CalibratorsSelectorMixin, law.tasks.ForestMerge):
+class MergeSelectionStats(DatasetTask, SelectorMixin, CalibratorsMixin, law.tasks.ForestMerge):
 
     shifts = set(SelectEvents.shifts)
 


### PR DESCRIPTION
This PR adds a mixin `SelectorStepsMixin`, which itself inherits from `SelectorMixin`, but adding a new parameter `--selector-steps`.

- `ReduceEvents` and all tasks below it inherit from the new mixin.
- When steps are defined, `ReduceEvents` itself applies the **event** selection no longer from the overall `sel.event` mask, but it composes a new boolean mask from the AND of the configured steps.
- Side note: I removed the `CalibratorsSelectorMixin` which was meant as a shorthand, but it's not really needed and makes mixin composition less dynamic.

This way, the entire task chain can be run with a subset of the actual selection steps, allowing for complex selection validations downstream.