### PR TITLE
Complex route lookups.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,14 @@ The task that you are about to start requires a valid voms proxy.
     # run your first task
     law run ReduceEvents --version v1 --dataset st_tchannel_t --branch 0
 
+    # create plots
+    law run PlotVariables \
+        --version v1 \
+        --datasets "st_tchannel_t,tt_sl" \
+        --producers variables \
+        --variables ht \
+        --workers 3
+
 
 Development
 -----------

--- a/ap/columnar_util.py
+++ b/ap/columnar_util.py
@@ -417,11 +417,9 @@ class Route(object):
                 pad_axis = 0
                 if isinstance(f, int):
                     max_idx = f
-                    pad_axis = 0
                 elif isinstance(f, list):
                     if all(isinstance(i, int) for i in f):
                         max_idx = max(f)
-                        pad_axis = 0
                 else:  # tuple
                     last = f[-1]
                     if isinstance(last, int):

--- a/ap/columnar_util.py
+++ b/ap/columnar_util.py
@@ -185,7 +185,7 @@ class Route(object):
         # TODO: a regexp would be far cleaner, but there are edge cases which possibly require
         #       sequential regexp evaluations which might be less maintainable
         slices = []
-        replacement = lambda i: f"__slice_{i}__"
+        repl = lambda i: f"__slice_{i}__"
         repl_cre = re.compile(r"^__slice_(\d+)__$")
         while True:
             depth = 0
@@ -193,7 +193,7 @@ class Route(object):
             for i, s in enumerate(column):
                 if s == "[":
                     depth += 1
-                    # remember the starting point when the slices started
+                    # remember the starting point when the slice started
                     if depth == 1:
                         slice_start = i
                 elif s == "]":
@@ -206,11 +206,11 @@ class Route(object):
                         slices.append(column[slice_start:i + 1])
                         # insert a temporary replacement
                         start = column[:slice_start]
-                        repl = replacement(len(slices) - 1)
+                        tmp = repl(len(slices) - 1)
                         rest = column[i + 1:]
                         if rest and not rest.startswith(sep):
                             raise ValueError(f"invalid column format '{column}'")
-                        column = start + (sep if start else "") + repl + rest
+                        column = start + (sep if start else "") + tmp + rest
                         # start over
                         break
             else:

--- a/ap/columnar_util.py
+++ b/ap/columnar_util.py
@@ -113,8 +113,8 @@ class Route(object):
 
     @classmethod
     def slice_to_str(cls, s: slice) -> str:
-        s_str = (str(s.start) if s.start else "") + ":"
-        s_str += str(s.stop) if s.stop is not None else ""
+        s_str = ("" if s.start is None else str(s.start)) + ":"
+        s_str += "" if s.stop is None else str(s.stop)
         if s.step is not None:
             s_str += f":{s.step}"
         return s_str

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -37,7 +37,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="electron1_pt",
-        expression="Electron.pt.0",
+        expression="Electron.pt[:,0]",
         null_value=EMPTY_FLOAT,
         binning=(40, 0., 400.),
         unit="GeV",
@@ -45,7 +45,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="muon1_pt",
-        expression="Muon.pt.0",
+        expression="Muon.pt[:,0]",
         null_value=EMPTY_FLOAT,
         binning=(40, 0., 400.),
         unit="GeV",
@@ -63,7 +63,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="jet1_pt",
-        expression="Jet.pt.0",
+        expression="Jet.pt[:,0]",
         null_value=EMPTY_FLOAT,
         binning=(40, 0., 400.),
         unit="GeV",
@@ -71,7 +71,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="jet2_pt",
-        expression="Jet.pt.1",
+        expression="Jet.pt[:,1]",
         null_value=EMPTY_FLOAT,
         binning=(40, 0., 400.),
         unit="GeV",
@@ -79,7 +79,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="jet3_pt",
-        expression="Jet.pt.2",
+        expression="Jet.pt[:,2]",
         null_value=EMPTY_FLOAT,
         binning=(40, 0., 400.),
         unit="GeV",
@@ -87,21 +87,21 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="jet1_eta",
-        expression="Jet.eta.0",
+        expression="Jet.eta[:,0]",
         null_value=EMPTY_FLOAT,
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 1 $\eta$",
     )
     config.add_variable(
         name="jet2_eta",
-        expression="Jet.eta.1",
+        expression="Jet.eta[:,1]",
         null_value=EMPTY_FLOAT,
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 2 $\eta$",
     )
     config.add_variable(
         name="jet3_eta",
-        expression="Jet.eta.2",
+        expression="Jet.eta[:,2]",
         null_value=EMPTY_FLOAT,
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 3 $\eta$",

--- a/ap/ml/__init__.py
+++ b/ap/ml/__init__.py
@@ -20,11 +20,20 @@ ak = maybe_import("awkward")
 class MLModel(object):
     """
     Minimal interface to ML models with connections to config objects (such as
-    py:class:`orderd.Config` or :py:class:`order.Dataset`) and, on an optional basis, to tasks.
+    py:class:`order.Config` or :py:class:`order.Dataset`) and, on an optional basis, to tasks.
 
-    Inheriting classes need to overwrite seven methods: :py:meth:`datasets`, :py:meth:`uses`,
-    :py:meth:`produces`, :py:meth:`output`, :py:meth:`open_model`, :py:meth:`train`, and
-    :py:meth:`evaluate`.
+    Inheriting classes need to overwrite eight methods:
+
+        - :py:meth:`sandbox`
+        - :py:meth:`datasets`
+        - :py:meth:`uses`,
+        - :py:meth:`produces`
+        - :py:meth:`output`
+        - :py:meth:`open_model`
+        - :py:meth:`train`
+        - :py:meth:`evaluate`
+
+    See their documentation below for more info.
 
     .. py:attribute:: name
        type: str
@@ -93,7 +102,7 @@ class MLModel(object):
         if name not in cls._instances:
             raise ValueError(f"no ML model named '{name}' found")
 
-        return _copy.copy(cls._instances[name]) if copy else cls._instances[name]
+        return _copy.deepcopy(cls._instances[name]) if copy else cls._instances[name]
 
     def __init__(
         self,

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -176,11 +176,8 @@ class CreateCutflowHistograms(
         for variable_inst in variable_insts:
             expr = variable_inst.expression
             if isinstance(expr, str):
-                expr = functools.partial(
-                    Route.select,
-                    route=Route.check(expr),
-                    null_value=variable_inst.null_value,
-                )
+                route = Route.check(expr)
+                expr = functools.partial(route.apply, null_value=variable_inst.null_value)
             expressions[variable_inst.name] = expr
 
         # create histograms per variable

--- a/ap/util.py
+++ b/ap/util.py
@@ -5,7 +5,7 @@ Collection of general helpers and utilities.
 """
 
 __all__ = [
-    "env_is_remote", "env_is_dev", "primes",
+    "UNSET", "env_is_remote", "env_is_dev", "primes",
     "FunctionArgs", "DotDict", "MockModule",
     "maybe_import", "import_plt", "import_ROOT", "create_random_name", "expand_path", "real_path",
     "wget", "call_thread", "call_proc", "ensure_proxy", "dev_sandbox", "safe_div",
@@ -26,6 +26,9 @@ from types import ModuleType
 
 import law
 
+
+#: Placeholder for an unset value.
+UNSET = object()
 
 #: Boolean denoting whether the environment is in a remote job (based on ``AP_REMOTE_JOB``).
 env_is_remote = law.util.flag_to_bool(os.getenv("AP_REMOTE_JOB", "0"))


### PR DESCRIPTION
This PR extends the route syntax and adds a new instance method, `Route.apply(array)`, which applies the fields of the route to an arbitrary array and returns the selection.

The fields can now contain complex selection and slicing statements, such as `"Jet.pt[0]"`, `"Jet.pt[:, 0]"` or `"Jet.pt[:, [2, 0, 1]]"`, and even `"[:10]Jet.pt[:, 0]"`.

The full list of possible options is given below:

|   String column   |                      Tuple syntax                      |                             Description                              |
| ----------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
| "Jet.pt"          | ("Jet", "pt")                                          | all jet pts                                                          |
| "Jet.pt[0]"       | ("Jet", "pt", 0)                                       | all jet pts of the first event                                       |
| "Jet[0].pt"       | ("Jet", 0, "pt")                                       | all jet pts of the first event                                       |
| "[0].Jet.pt"      | (0, "Jet", "pt")                                       | all jet pts of the first event                                       |
| "Jet.pt[:,0]"     | ("Jet", "pt", (slice(None, None), 0))                  | first jet pt of all events                                           |
| "Jet.pt[...,0]"   | ("Jet", "pt", (Ellipsis, 0))                           | first jet pt of all events in a possibly deeper structure            |
| "Jet.pt[:,:2]"    | ("Jet", "pt", (slice(None, None), slice(None, 2)))     | the first two jet pts of all events                                  |
| "Jet.pt[:,:2:-1]" | ("Jet", "pt", (slice(None, None), slice(None, 2, -1))) | all jets except the last two in reversed order of all events         |
| "Jet.pt[:,[1,0]]" | ("Jet", "pt", (slice(None, None), [1, 0]))             | the first two jet pts of all events in reversed order                |
| "Jet.pt[:2]"      | ("Jet", "pt", slice(None, 2))                          | all jet pts of the first two events                                  |
| "Jet.pt[:2:-1]"   | ("Jet", "pt", slice(None, 2, -1))                      | all jet pts of the all events except the first two in reversed order |
| "Jet.pt[[1,0]]"   | ("Jet", "pt", [1, 0])                                  | all jet pts of the first two events in reversed order                |

I also updated some of the variables to use this new syntax.

Closes #56.