### PR TITLE
Refactor array function stacks.

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -85,7 +85,7 @@ jobs:
           ./tests/run_coverage
 
       - name: Upload report 🔝
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_test_util.xml,./coverage_test_columnar_util.xml

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -83,12 +83,13 @@ jobs:
           cd "${AP_JOB_ID}"
           source setup.sh ""
           ./tests/run_coverage
+          ls -al
 
       - name: Upload report 🔝
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage_test_util.xml,./coverage_test_columnar_util.xml
+          files: coverage_test_util.xml,coverage_test_columnar_util.xml
           flags: unittests
 
       - name: Cleanup 🧹

--- a/ap/calibration/__init__.py
+++ b/ap/calibration/__init__.py
@@ -6,21 +6,31 @@ Object and event calibration tools.
 
 from typing import Optional, Union, Callable
 
+from ap.util import DerivableMeta
 from ap.columnar_util import TaskArrayFunction
 
 
-class Calibrator(TaskArrayFunction):
-
-    # dedicated instance cache
-    _instances = {}
+Calibrator = TaskArrayFunction.derive("Calibrator")
 
 
-def calibrator(func: Optional[Callable] = None, **kwargs) -> Union[Calibrator, Callable]:
+def calibrator(
+    func: Optional[Callable] = None,
+    bases=(),
+    **kwargs,
+) -> Union[DerivableMeta, Callable]:
     """
-    Decorator for registering new calibrator functions. All *kwargs* are forwarded to the
-    :py:class:`Calibrator` constructor.
+    Decorator for creating a new :py:class:`Calibrator` subclass with additional, optional *bases*
+    and attaching the decorated function to it as ``call_func``. All *kwargs* will become default
+    constructor arguments of the new class.
     """
-    def decorator(func):
-        return Calibrator.new(func, **kwargs)
+    def decorator(func: Callable) -> DerivableMeta:
+        # create the class dict
+        cls_dict = {"call_func": func}
+        cls_dict.update(kwargs)
+
+        # create the subclass
+        subclass = Calibrator.derive(func.__name__, bases=bases, cls_dict=cls_dict)
+
+        return subclass
 
     return decorator(func) if func else decorator

--- a/ap/calibration/test.py
+++ b/ap/calibration/test.py
@@ -5,9 +5,9 @@ Calibration methods for testing purposes.
 """
 
 from ap.calibration import Calibrator, calibrator
+from ap.production.seeds import deterministic_seeds
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
-from ap.production.seeds import deterministic_seeds
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -50,8 +50,8 @@ def jec_test(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     produces={jec_test, deterministic_seeds},
 )
 def test(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
-    self.stack.jec_test(events, **kwargs)
+    self[jec_test](events, **kwargs)
 
-    self.stack.deterministic_seeds(events, **kwargs)
+    self[deterministic_seeds](events, **kwargs)
 
     return events

--- a/ap/production/__init__.py
+++ b/ap/production/__init__.py
@@ -6,20 +6,31 @@ Tools for producing new array columns (e.g. high-level variables).
 
 from typing import Optional, Union, Callable
 
+from ap.util import DerivableMeta
 from ap.columnar_util import TaskArrayFunction
 
 
-class Producer(TaskArrayFunction):
-
-    _instances = {}
+Producer = TaskArrayFunction.derive("Producer")
 
 
-def producer(func: Optional[Callable] = None, **kwargs) -> Union[Producer, Callable]:
+def producer(
+    func: Optional[Callable] = None,
+    bases=(),
+    **kwargs,
+) -> Union[DerivableMeta, Callable]:
     """
-    Decorator for registering new producer functions. All *kwargs* are forwarded to the
-    :py:class:`Producer` constructor.
+    Decorator for creating a new :py:class:`Producer` subclass with additional, optional *bases* and
+    attaching the decorated function to it as ``call_func``. All *kwargs* will become default
+    constructor arguments of the new class.
     """
-    def decorator(func):
-        return Producer.new(func, **kwargs)
+    def decorator(func: Callable) -> DerivableMeta:
+        # create the class dict
+        cls_dict = {"call_func": func}
+        cls_dict.update(kwargs)
+
+        # create the subclass
+        subclass = Producer.derive(func.__name__, bases=bases, cls_dict=cls_dict)
+
+        return subclass
 
     return decorator(func) if func else decorator

--- a/ap/production/categories.py
+++ b/ap/production/categories.py
@@ -5,7 +5,6 @@ Column production methods related defining categories.
 """
 
 import law
-import order as od
 
 from ap.selection import Selector
 from ap.production import Producer, producer
@@ -15,30 +14,23 @@ from ap.columnar_util import set_ak_column
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
-
 logger = law.logger.get_logger(__name__)
 
 
 @producer(produces={"category_ids"})
-def category_ids(
-    self: Producer,
-    events: ak.Array,
-    config_inst: od.Config,
-    dataset_inst: od.Dataset,
-    **kwargs,
-) -> ak.Array:
+def category_ids(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Assigns each event an array of category ids.
     """
     category_ids = []
 
     # TODO: we maybe don't want / need to loop through all leaf categories
-    for cat_inst in config_inst.get_leaf_categories():
-        # get the selector
+    for cat_inst in self.config_inst.get_leaf_categories():
+        # get the selector class
         selector = self.category_to_selector[cat_inst]
 
         # get the category mask
-        cat_mask = selector(events, config_inst=config_inst, dataset_inst=dataset_inst, **kwargs)
+        cat_mask = self[selector](events, **kwargs)
 
         # covert to nullable array with the category ids or none, then apply ak.singletons
         cat_ids = ak.singletons(ak.Array(np.where(np.asarray(cat_mask), cat_inst.id, None)))
@@ -50,23 +42,15 @@ def category_ids(
     return events
 
 
-@category_ids.update
-def category_ids_update(self: Producer, config_inst: od.Config, **kwargs) -> None:
-    # store a mapping from leaf category to selector instance for faster lookup
+@category_ids.init
+def category_ids_init(self: Producer) -> None:
+    # store a mapping from leaf category to selector class for faster lookup
     self.category_to_selector = {}
 
     # add all selectors obtained from leaf category selection expressions to the used columns
-    for cat_inst in config_inst.get_leaf_categories():
+    for cat_inst in self.config_inst.get_leaf_categories():
         sel = cat_inst.selection
-        if isinstance(sel, Selector):
-            selector = sel
-        elif isinstance(sel, str) and Selector.has(sel):
-            selector = Selector.get(sel)
-        else:
-            raise Exception(
-                f"selection '{sel}' of category {cat_inst.name} does not refer to an existing "
-                "selector",
-            )
+        selector = sel if Selector.derived_by(sel) else Selector.get_cls(sel)
 
         # variables should refer to unexposed selectors as they should usually not
         # return SelectionResult's but a flat per-event mask
@@ -76,12 +60,8 @@ def category_ids_update(self: Producer, config_inst: od.Config, **kwargs) -> Non
                 "whose return value is most likely incompatible with category masks",
             )
 
-        # create a copy
-        selector = selector.updated_copy(config_inst=config_inst, **kwargs)
-
-        # update sets
+        # update dependency sets
         self.uses.add(selector)
         self.produces.add(selector)
-        self.shifts.add(selector)
 
         self.category_to_selector[cat_inst] = selector

--- a/ap/production/features.py
+++ b/ap/production/features.py
@@ -36,6 +36,6 @@ def variables(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     set_ak_column(events, "n_deepjet", ak.num(events.Jet.pt[events.Jet.btagDeepFlavB > 0.3], axis=1))
 
     # add event weights
-    self.stack.event_weights(events, **kwargs)
+    self[event_weights](events, **kwargs)
 
     return events

--- a/ap/production/gen_top_decay.py
+++ b/ap/production/gen_top_decay.py
@@ -4,8 +4,6 @@
 Producers that determine the generator-level particles related to a top quark decay.
 """
 
-import order as od
-
 from ap.production import Producer, producer
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
@@ -18,12 +16,7 @@ ak = maybe_import("awkward")
     uses={"nGenPart", "GenPart.*"},
     produces={"gen_top_decay"},
 )
-def gen_top_decay_products(
-    self: Producer,
-    events: ak.Array,
-    dataset_inst: od.Dataset,
-    **kwargs,
-) -> ak.Array:
+def gen_top_decay_products(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Creates a new ragged column "gen_top_decay" with one element per hard top quark. Each element is
     a GenParticleArray with five objects in a distinct order: top quark, bottom quark, W boson,
@@ -34,7 +27,7 @@ def gen_top_decay_products(
 
         [[t1, W1, b1, q1, q2], [t2, ...], ...]
     """
-    if dataset_inst.is_data or not dataset_inst.x("has_top", False):
+    if self.dataset_inst.is_data or not self.dataset_inst.x("has_top", False):
         return events
 
     # find hard top quarks

--- a/ap/production/pileup.py
+++ b/ap/production/pileup.py
@@ -4,9 +4,6 @@
 Column production methods related to pileup weights.
 """
 
-import law
-import order as od
-
 from ap.production import Producer, producer
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
@@ -18,64 +15,51 @@ ak = maybe_import("awkward")
     uses={"PV.npvs"},
     produces={"pu_weight", "pu_weight_minbias_xs_up", "pu_weight_minbias_xs_down"},
 )
-def pu_weights(
-    self: Producer,
-    events: ak.Array,
-    pu_weights: ak.Array,
-    dataset_inst: od.Dataset,
-    **kwargs,
-) -> ak.Array:
+def pu_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Based on the number of primary vertices, assigns each event pileup weights using the profile
-    of pileup ratios *pu_weights* that is provided by the requires and setup functions below.
+    of pileup ratios at the py:attr:`pu_weights` attribute provided by the requires and setup
+    functions below.
     """
     # stop here for data
-    if dataset_inst.is_data:
+    if self.dataset_inst.is_data:
         return events
 
     # compute the indices for looking up weights
     indices = events.PV.npvs.to_numpy() - 1
-    max_bin = len(pu_weights) - 1
+    max_bin = len(self.pu_weights) - 1
     indices[indices > max_bin] = max_bin
 
     # save the weights
-    set_ak_column(events, "pu_weight", pu_weights.nominal[indices])
-    set_ak_column(events, "pu_weight_minbias_xs_up", pu_weights.minbias_xs_up[indices])
-    set_ak_column(events, "pu_weight_minbias_xs_down", pu_weights.minbias_xs_down[indices])
+    set_ak_column(events, "pu_weight", self.pu_weights.nominal[indices])
+    set_ak_column(events, "pu_weight_minbias_xs_up", self.pu_weights.minbias_xs_up[indices])
+    set_ak_column(events, "pu_weight_minbias_xs_down", self.pu_weights.minbias_xs_down[indices])
 
     return events
 
 
 @pu_weights.requires
-def pu_weights_requires(self: Producer, task: law.Task, reqs: dict) -> dict:
+def pu_weights_requires(self: Producer, reqs: dict) -> None:
     """
-    Adds the requirements needed by *task* to derive the pileup weights into *reqs*.
+    Adds the requirements needed the underlying task to derive the pileup weights into *reqs*.
     """
     # do nothing for data
-    if task.dataset_inst.is_data:
+    if self.dataset_inst.is_data:
         return reqs
 
     from ap.tasks.external import CreatePileupWeights
-    reqs["pu_weights"] = CreatePileupWeights.req(task)
-
-    return reqs
+    reqs["pu_weights"] = CreatePileupWeights.req(self.task)
 
 
 @pu_weights.setup
-def pu_weights_setup(
-    self: Producer,
-    task: law.Task,
-    inputs: dict,
-    call_kwargs: dict,
-    **kwargs,
-) -> None:
+def pu_weights_setup(self: Producer, inputs: dict) -> None:
     """
-    Loads the pileup weights added through the requirements and saves them in the *call_kwargs* for
-    simpler access in the actual callable.
+    Loads the pileup weights added through the requirements and saves them in the
+    py:attr:`pu_weights` attribute for simpler access in the actual callable.
     """
     # set to None for data
-    if task.dataset_inst.is_data:
-        call_kwargs.setdefault("pu_weights", None)
+    if self.dataset_inst.is_data:
+        self.pu_weights = None
         return
 
-    call_kwargs["pu_weights"] = ak.zip(inputs["pu_weights"].load(formatter="json"))
+    self.pu_weights = ak.zip(inputs["pu_weights"].load(formatter="json"))

--- a/ap/production/processes.py
+++ b/ap/production/processes.py
@@ -4,8 +4,6 @@
 Column production methods related detecting truth processes.
 """
 
-import order as od
-
 from ap.production import Producer, producer
 from ap.util import maybe_import
 from ap.columnar_util import set_ak_column
@@ -16,19 +14,19 @@ ak = maybe_import("awkward")
 @producer(
     produces={"process_id"},
 )
-def process_ids(self: Producer, events: ak.Array, dataset_inst: od.Dataset, **kwargs) -> ak.Array:
+def process_ids(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Assigns each event a single process id, based on the first process that is registered for the
-    *dataset_inst*. This is rather a dummy method and should be further implemented depending on
-    future needs (e.g. for sample stitching).
+    internal py:attr:`dataset_inst`. This is rather a dummy method and should be further implemented
+    depending on future needs (e.g. for sample stitching).
     """
     # trivial case
-    if len(dataset_inst.processes) != 1:
+    if len(self.dataset_inst.processes) != 1:
         raise NotImplementedError(
-            f"dataset {dataset_inst.name} has {len(dataset_inst.processes)} processes assigned, "
-            "which is not yet implemented",
+            f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
+            "assigned, which is not yet implemented",
         )
-    process_id = dataset_inst.processes.get_first().id
+    process_id = self.dataset_inst.processes.get_first().id
 
     # store the column
     set_ak_column(events, "process_id", len(events) * [process_id])

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -37,8 +37,8 @@ class MergeSelectionMasks(
         super().__init__(*args, **kwargs)
 
         # store the normalization weight producer
-        self.norm_weight_producer = Producer.get("normalization_weights").updated_copy(
-            **self.get_producer_kwargs(self),
+        self.norm_weight_producer = Producer.get_cls("normalization_weights")(
+            inst_dict=self.get_producer_kwargs(self),
         )
 
     def create_branch_map(self):
@@ -48,13 +48,13 @@ class MergeSelectionMasks(
     def merge_workflow_requires(self):
         return {
             "selection": SelectEvents.req(self, _exclude={"branches"}),
-            "normalization": self.norm_weight_producer.run_requires(self),
+            "normalization": self.norm_weight_producer.run_requires(),
         }
 
     def merge_requires(self, start_branch, end_branch):
         return {
             "selection": [SelectEvents.req(self, branch=b) for b in range(start_branch, end_branch)],
-            "normalization": self.norm_weight_producer.run_requires(self),
+            "normalization": self.norm_weight_producer.run_requires(),
         }
 
     def trace_merge_workflow_inputs(self, inputs):
@@ -83,8 +83,7 @@ class MergeSelectionMasks(
         chunks = []
 
         # setup the normalization weights producer
-        self.norm_weight_producer.run_setup(self, self.input()["forest_merge"]["normalization"])
-        producer_kwargs = self.get_producer_kwargs(self)
+        self.norm_weight_producer.run_setup(self.input()["forest_merge"]["normalization"])
 
         # get columns to keep
         keep_columns = set(self.config_inst.x.keep_columns[self.task_family])
@@ -95,7 +94,7 @@ class MergeSelectionMasks(
             steps = inp["results"].load(formatter="awkward").steps
 
             # add normalization weight
-            self.norm_weight_producer(events, **producer_kwargs)
+            self.norm_weight_producer(events)
 
             # remove columns
             events = route_filter(events)

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -106,13 +106,10 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
     @classmethod
     def get_array_function_kwargs(cls, task=None, **params):
-        kwargs = {}
-        if task:
-            kwargs["task"] = task
-            kwargs["analysis_inst"] = task.analysis_inst
-        else:
-            kwargs["analysis_inst"] = cls.get_analysis_inst(cls.analysis)
-        return kwargs
+        return {
+            "task": task,
+            "analysis_inst": task.analysis_inst if task else cls.get_analysis_inst(cls.analysis),
+        }
 
     @classmethod
     def get_calibrator_kwargs(cls, task=None, **params):
@@ -496,7 +493,11 @@ class DatasetTask(ShiftTask):
             requested_dataset = params.get("dataset")
             if requested_dataset not in (None, law.NO_STR):
                 dataset_inst = config_inst.get_dataset(requested_dataset)
-                allowed_shifts |= set(dataset_inst.info.keys())
+                # clear shifts for data and extend with dataset variations for mc
+                if dataset_inst.is_data:
+                    allowed_shifts.clear()
+                else:
+                    allowed_shifts |= set(dataset_inst.info.keys())
 
         return allowed_shifts
 

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -4,7 +4,7 @@
 Lightweight mixins task classes.
 """
 
-from typing import Union, Sequence, List, Set, Dict, Any, Optional
+from typing import Union, Sequence, List, Set, Dict, Any
 
 import law
 import luigi
@@ -25,8 +25,6 @@ class CalibratorMixin(ConfigTask):
         "'default_calibrator' config",
     )
 
-    update_calibrator = False
-
     @classmethod
     def modify_param_values(cls, params):
         params = super().modify_param_values(params)
@@ -45,37 +43,33 @@ class CalibratorMixin(ConfigTask):
 
         # get the calibrator, update it and add its shifts
         if params.get("calibrator") not in (None, law.NO_STR):
-            calibrator_func = cls.get_calibrator_func(
+            calibrator_inst = cls.get_calibrator_inst(
                 params["calibrator"],
-                **(cls.get_calibrator_kwargs(**params) if cls.update_calibrator else {}),
+                cls.get_calibrator_kwargs(**params),
             )
-            shifts |= calibrator_func.all_shifts
+            shifts |= calibrator_inst.all_shifts
 
         return shifts
 
     @classmethod
-    def get_calibrator_func(cls, calibrator, copy=True, **update_kwargs):
-        func = Calibrator.get(calibrator, copy=copy)
-        if update_kwargs:
-            func.run_update(**update_kwargs)
-
-        return func
+    def get_calibrator_inst(cls, calibrator, inst_dict=None):
+        return Calibrator.get_cls(calibrator)(inst_dict=inst_dict)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cache for calibrator func
-        self._calibrator_func = None
+        # cache for calibrator inst
+        self._calibrator_inst = None
 
     @property
-    def calibrator_func(self):
-        if self._calibrator_func is None:
-            # store a copy of the calibrator
-            self._calibrator_func = self.get_calibrator_func(
+    def calibrator_inst(self):
+        if self._calibrator_inst is None:
+            # store a calibrator instance
+            self._calibrator_inst = self.get_calibrator_inst(
                 self.calibrator,
-                **(self.get_calibrator_kwargs(self) if self.update_calibrator else {}),
+                self.get_calibrator_kwargs(self),
             )
-        return self._calibrator_func
+        return self._calibrator_inst
 
     def store_parts(self):
         parts = super().store_parts()
@@ -90,8 +84,6 @@ class CalibratorsMixin(ConfigTask):
         description="comma-separated names of calibrators to be applied; default: value of the "
         "'default_calibrator' config in a 1-tuple",
     )
-
-    update_calibrators = False
 
     @classmethod
     def modify_param_values(cls, params):
@@ -110,37 +102,33 @@ class CalibratorsMixin(ConfigTask):
 
         # get the calibrators, update them and add their shifts
         if params.get("calibrators") not in (None, law.NO_STR):
-            calibrator_kwargs = cls.get_calibrator_kwargs(**params) if cls.update_calibrators else {}
+            calibrator_kwargs = cls.get_calibrator_kwargs(**params)
             for calibrator in params["calibrators"]:
-                calibrator_func = cls.get_calibrator_func(calibrator, **calibrator_kwargs)
-                shifts |= calibrator_func.all_shifts
+                calibrator_inst = cls.get_calibrator_inst(calibrator, calibrator_kwargs)
+                shifts |= calibrator_inst.all_shifts
 
         return shifts
 
     @classmethod
-    def get_calibrator_func(cls, calibrator, copy=True, **update_kwargs):
-        func = Calibrator.get(calibrator, copy=copy)
-        if update_kwargs:
-            func.run_update(**update_kwargs)
-
-        return func
+    def get_calibrator_inst(cls, calibrator, inst_dict=None):
+        return Calibrator.get_cls(calibrator)(inst_dict=inst_dict)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cache for calibrator funcs
-        self._calibrator_funcs = None
+        # cache for calibrator insts
+        self._calibrator_insts = None
 
     @property
-    def calibrator_funcs(self):
-        if self._calibrator_funcs is None:
-            # store copies of all calibrators
-            calibrator_kwargs = self.get_calibrator_kwargs(self) if self.update_calibrators else {}
-            self._calibrator_funcs = [
-                self.get_calibrator_func(calibrator, **calibrator_kwargs)
+    def calibrator_insts(self):
+        if self._calibrator_insts is None:
+            # store instances of all calibrators
+            calibrator_kwargs = self.get_calibrator_kwargs(self)
+            self._calibrator_insts = [
+                self.get_calibrator_inst(calibrator, calibrator_kwargs)
                 for calibrator in self.calibrators
             ]
-        return self._calibrator_funcs
+        return self._calibrator_insts
 
     def store_parts(self):
         parts = super().store_parts()
@@ -161,8 +149,6 @@ class SelectorMixin(ConfigTask):
         "'default_selector' config",
     )
 
-    update_selector = False
-
     @classmethod
     def modify_param_values(cls, params):
         params = super().modify_param_values(params)
@@ -181,39 +167,38 @@ class SelectorMixin(ConfigTask):
 
         # get the selector, update it and add its shifts
         if params.get("selector") not in (None, law.NO_STR):
-            selector_func = cls.get_selector_func(
+            selector_inst = cls.get_selector_inst(
                 params["selector"],
-                **(cls.get_selector_kwargs(**params) if cls.update_selector else {}),
+                cls.get_selector_kwargs(**params),
             )
-            shifts |= selector_func.all_shifts
+            shifts |= selector_inst.all_shifts
 
         return shifts
 
     @classmethod
-    def get_selector_func(cls, selector, copy=True, **update_kwargs):
-        func = Selector.get(selector, copy=copy)
-        if not func.exposed:
-            raise RuntimeError(f"cannot use unexposed selector '{selector}' in {cls.__name__}")
-        if update_kwargs:
-            func.run_update(**update_kwargs)
+    def get_selector_inst(cls, selector, inst_dict=None):
+        selector_cls = Selector.get_cls(selector)
 
-        return func
+        if not selector_cls.exposed:
+            raise RuntimeError(f"cannot use unexposed selector '{selector}' in {cls.__name__}")
+
+        return selector_cls(inst_dict=inst_dict)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cache for selector func
-        self._selector_func = None
+        # cache for selector inst
+        self._selector_inst = None
 
     @property
-    def selector_func(self):
-        if self._selector_func is None:
-            # store a copy of the selector
-            self._selector_func = self.get_selector_func(
+    def selector_inst(self):
+        if self._selector_inst is None:
+            # store a selector instance
+            self._selector_inst = self.get_selector_inst(
                 self.selector,
-                **(self.get_selector_kwargs(self) if self.update_selector else {}),
+                self.get_selector_kwargs(self),
             )
-        return self._selector_func
+        return self._selector_inst
 
     def store_parts(self):
         parts = super().store_parts()
@@ -268,8 +253,6 @@ class ProducerMixin(ConfigTask):
         "'default_producer' config",
     )
 
-    update_producer = False
-
     @classmethod
     def modify_param_values(cls, params):
         params = super().modify_param_values(params)
@@ -288,37 +271,33 @@ class ProducerMixin(ConfigTask):
 
         # get the producer, update it and add its shifts
         if params.get("producer") not in (None, law.NO_STR):
-            producer_func = cls.get_producer_func(
+            producer_inst = cls.get_producer_inst(
                 params["producer"],
-                **(cls.get_producer_kwargs(**params) if cls.update_producer else {}),
+                cls.get_producer_kwargs(**params),
             )
-            shifts |= producer_func.all_shifts
+            shifts |= producer_inst.all_shifts
 
         return shifts
 
     @classmethod
-    def get_producer_func(cls, producer, copy=True, **update_kwargs):
-        func = Producer.get(producer, copy=copy)
-        if update_kwargs:
-            func.run_update(**update_kwargs)
-
-        return func
+    def get_producer_inst(cls, producer, inst_dict=None):
+        return Producer.get_cls(producer)(inst_dict=inst_dict)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cache for producer func
-        self._producer_func = None
+        # cache for producer inst
+        self._producer_inst = None
 
     @property
-    def producer_func(self):
-        if self._producer_func is None:
-            # store a copy of the producer
-            self._producer_func = self.get_producer_func(
+    def producer_inst(self):
+        if self._producer_inst is None:
+            # store a producer instance
+            self._producer_inst = self.get_producer_inst(
                 self.producer,
-                **(self.get_producer_kwargs(self) if self.update_producer else {}),
+                self.get_producer_kwargs(self),
             )
-        return self._producer_func
+        return self._producer_inst
 
     def store_parts(self):
         parts = super().store_parts()
@@ -333,8 +312,6 @@ class ProducersMixin(ConfigTask):
         default=(),
         description="comma-separated names of producers to be applied; empty default",
     )
-
-    update_producers = False
 
     @classmethod
     def modify_param_values(cls, params):
@@ -353,46 +330,43 @@ class ProducersMixin(ConfigTask):
 
         # get the producers, update them and add their shifts
         if params.get("producers") not in (None, law.NO_STR):
-            producer_kwargs = cls.get_producer_kwargs(**params) if cls.update_producers else {}
+            producer_kwargs = cls.get_producer_kwargs(**params)
             for producer in params["producers"]:
-                producer_func = cls.get_producer_func(producer, **producer_kwargs)
-                shifts |= producer_func.all_shifts
+                producer_inst = cls.get_producer_inst(producer, producer_kwargs)
+                shifts |= producer_inst.all_shifts
 
         return shifts
 
     @classmethod
-    def get_producer_func(cls, producer, copy=True, **update_kwargs):
-        func = Producer.get(producer, copy=copy)
-        if update_kwargs:
-            func.run_update(**update_kwargs)
-
-        return func
+    def get_producer_inst(cls, producer, inst_dict=None):
+        return Producer.get_cls(producer)(inst_dict=inst_dict)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # cache for producer funcs
-        self._producer_funcs = None
+        # cache for producer insts
+        self._producer_insts = None
 
     @property
-    def producer_funcs(self):
-        if self._producer_funcs is None:
-            # store copies of all producers
-            producer_kwargs = self.get_producer_kwargs(self) if self.update_producers else {}
-            self._producer_funcs = [
-                self.get_producer_func(producer, **producer_kwargs)
+    def producer_insts(self):
+        if self._producer_insts is None:
+            # store instances of all producers
+            producer_kwargs = self.get_producer_kwargs(self)
+            self._producer_insts = [
+                self.get_producer_inst(producer, producer_kwargs)
                 for producer in self.producers
             ]
-        return self._producer_funcs
+        return self._producer_insts
 
     def store_parts(self):
         parts = super().store_parts()
 
+        part = "none"
         if self.producers:
             part = "__".join(self.producers[:5])
             if len(self.producers) > 5:
                 part += f"__{law.util.create_hash(self.producers[5:])}"
-            parts.insert_before("version", "producers", f"prod__{part}")
+        parts.insert_before("version", "producers", f"prod__{part}")
 
         return parts
 
@@ -415,30 +389,23 @@ class MLModelMixin(ConfigTask):
             if params.get("ml_model") == law.NO_STR and config_inst.x("default_ml_model", None):
                 params["ml_model"] = config_inst.x.default_ml_model
 
-            # initialize it once to trigger its set_config hook
+            # special case: initialize it once to trigger its set_config hook
             if params.get("ml_model") not in (law.NO_STR, None):
                 cls.get_ml_model_inst(params["ml_model"], config_inst)
 
         return params
 
     @classmethod
-    def get_ml_model_inst(
-        cls,
-        ml_model: str,
-        config_inst: Optional[od.Config] = None,
-        copy: bool = True,
-    ) -> MLModel:
-        ml_model_inst = MLModel.get(ml_model, copy=True)
-        if config_inst:
-            ml_model_inst.set_config(config_inst)
-
-        return ml_model_inst
+    def get_ml_model_inst(cls, ml_model: str, config_inst: od.Config) -> MLModel:
+        return MLModel.get_cls(ml_model)(config_inst)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # get the ML model instance
-        self.ml_model_inst = self.get_ml_model_inst(self.ml_model, self.config_inst)
+        self.ml_model_inst = None
+        if self.ml_model != law.NO_STR:
+            self.ml_model_inst = self.get_ml_model_inst(self.ml_model, self.config_inst)
 
     def events_used_in_training(self, dataset_inst: od.Dataset, shift_inst: od.Shift) -> bool:
         # evaluate whether the events for the combination of dataset_inst and shift_inst
@@ -450,7 +417,7 @@ class MLModelMixin(ConfigTask):
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-        ml_model = f"ml__{self.ml_model}" if self.ml_model != law.NO_STR else "none"
+        ml_model = f"ml__{self.ml_model}" if self.ml_model_inst else "none"
         parts.insert_before("version", "ml_model", ml_model)
         return parts
 
@@ -471,7 +438,7 @@ class MLModelsMixin(ConfigTask):
             if params.get("ml_models") == () and config_inst.x("default_ml_model", None):
                 params["ml_models"] = (config_inst.x.default_ml_model,)
 
-            # initialize them once to trigger their set_config hook
+            # special case: initialize them once to trigger their set_config hook
             if params.get("ml_models"):
                 for ml_model in params["ml_models"]:
                     MLModelMixin.get_ml_model_inst(ml_model, config_inst)
@@ -489,11 +456,8 @@ class MLModelsMixin(ConfigTask):
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-
-        if self.ml_models:
-            part = "__".join(self.ml_models)
-            parts.insert_before("version", "ml_models", f"ml__{part}")
-
+        part = "__".join(self.ml_models) if self.ml_model_insts else "none"
+        parts.insert_before("version", "ml_models", f"ml__{part}")
         return parts
 
 

--- a/ap/tasks/ml.py
+++ b/ap/tasks/ml.py
@@ -226,19 +226,20 @@ class MLTraining(MLModelMixin, ProducersMixin, SelectorMixin, CalibratorsMixin):
         "the number of folds defined in the ML model; default: 0",
     )
 
-    sandbox = None
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # set the sandbox
-        self.sandbox = self.ml_model_inst.sandbox(self)
-
+        # verify the fold
         if not (0 <= self.fold < self.ml_model_inst.folds):
             raise ValueError(
                 "the fold index is incompatible with the number of folds "
                 f"({self.ml_model_inst.fold}) for the ML model '{self.ml_model}'",
             )
+
+    @property
+    def sandbox(self):
+        # determine the sandbox dynamically based on the response of the model
+        return self.ml_model_inst.sandbox(self)
 
     def requires(self):
         return {

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -29,7 +29,8 @@ class ProcessPlotBase(
 
     def store_parts(self):
         parts = super().store_parts()
-        parts["plot"] = f"datasets_{self.datasets_repr}__processes_{self.processes_repr}"
+        part = f"datasets_{self.datasets_repr}__processes_{self.processes_repr}"
+        parts.insert_before("version", "plot", part)
         return parts
 
 

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -88,7 +88,7 @@ class ReduceEvents(DatasetTask, SelectorStepsMixin, CalibratorsMixin, law.LocalW
         input_paths = [nano_file]
         input_paths.append(inputs["selection"]["results"].path)
         input_paths.extend([inp.path for inp in inputs["calibrations"]])
-        if self.selector_func.produced_columns:
+        if self.selector_inst.produced_columns:
             input_paths.append(inputs["selection"]["columns"].path)
         with ChunkedReader(
             input_paths,

--- a/law.cfg
+++ b/law.cfg
@@ -18,7 +18,7 @@ ap.tasks.cutflow
 
 [analysis]
 
-production_modules: ap.production.{processes,features,pileup,normalization,seeds,weights}
+production_modules: ap.production.{categories,processes,features,pileup,normalization,seeds,weights}
 calibration_modules: ap.calibration.{test,jets}
 selection_modules: ap.selection.test
 ml_modules: ap.ml.test

--- a/tests/run_coverage
+++ b/tests/run_coverage
@@ -20,7 +20,7 @@ action() {
             ( cd "$ap_dir"; pytest --cov=ap --cov-report xml:coverage_${mod}.xml "tests/${mod}.py" )
         else
             echo "testing ${mod} in sandbox ${sandbox} ..."
-            ( cd "$ap_dir"; bash -c "source sandboxes/${sandbox} && echo \"running coverage in tests/${mod}.py\" && pytest --cov=ap --cov-report xml:coverage_${mod}.xml tests/${mod}.py" )
+            ( cd "$ap_dir"; bash -c "source sandboxes/${sandbox} && pytest --cov=ap --cov-report xml:coverage_${mod}.xml tests/${mod}.py" )
         fi
     }
 


### PR DESCRIPTION
This PR is changes the internal structure of call stacks in `(Task)ArrayFunction`'s, and is therefore very technical.

I'll try to summarize the changes from a more high-level view, because the low-level changes are better to be understood directly from the code :)

## Before

Producer, Selector and Calibrator classes inherited from Array functions (and they still do), but the usable, named objects were already instances. E.g. by decorating a function with `@producer`, the return value was an instance of the `Producer` class. However, at some point, the instances started having a state to model the dependence between different configs, datasets, shifts, etc. To make call stacks (e.g. one producer calling another) consistent, interdependent producers had to keep copies of one another, so that, when calling one another, the one with the correct state was called. This worked, but the approach was very cumbersome and felt unnatural.

## Now

`@producer`, `@selector` and `@calibrator` now returned a class derived from the `Producer`, `Selector` or `Calibrator` base classes. These classes act a blueprint for creating actual instances (since well... it's a class), passing to their creation all infos regarding used / produced columns, shifts, etc. However, the instances are allowed to change that info depending on the config / datasets / ... they receive. Also, upon instantiation, they create instances of their dependencies (other array functions in produces / datasets / shifts), which properly encapsulates their state in a pure OOP way. Hard to explain, but everything falls into place now :)

Within a call, dependent array function *instances* can be accessed via items, using their class as a key. Example:

```python
@producer(uses={"Jet.pt"}, produces={"Jet.pt2"})
def foo(self, events):
    events["Jet", "pt2"] = events.Jet.pt ** 2

# foo is a class!
# now we define bar (also a class) that declares its dependence on foo
# using the PRODUCES flag

@producer(uses={foo.PRODUCES}, produces={"Jet.pt4"})
def bar(self, events):
    # call the correct foo instance, using the foo class a key for the lookup
    self[foo](events)

    events["Jet", "pt4"] = events.Jet.pt2 ** 2


# call bar on a chunk of events
inst = bar()  # <-- this is where the call stack is built

inst(events)
```
