### PR TITLE
Store and apply event weight sums per process.

### DIFF
--- a/ap/production/normalization.py
+++ b/ap/production/normalization.py
@@ -36,10 +36,14 @@ def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Arra
     lumi = self.config_inst.x.luminosity.nominal
 
     # read the cross section per process from the lookup table
-    xs = np.array(self.xs_table[0, np.asarray(events.process_id)].todense())[0]
+    process_id = np.asarray(events.process_id)
+    xs = np.array(self.xs_table[0, process_id].todense())[0]
+
+    # read the sum of event weights per process from the lookup table
+    sum_weights = np.array(self.sum_weights_table[0, process_id].todense())[0]
 
     # compute the weight and store it
-    norm_weight = events.LHEWeight.originalXWGTUP * lumi * xs / self.selection_stats["sum_mc_weight"]
+    norm_weight = events.LHEWeight.originalXWGTUP * lumi * xs / sum_weights
     set_ak_column(events, "normalization_weight", norm_weight)
 
     return events
@@ -69,8 +73,10 @@ def normalization_weights_setup(self: Producer, inputs: dict) -> None:
     attributes:
 
         - py:attr:`selection_stats`: The stats dict loaded from the output of MergeSelectionsStats.
-        - py:attr:`xs_table`: A sparse array serving as a lookup table for all processes known to
-          the config of the task, with keys being process ids.
+        - py:attr:`sum_weights_table`: A sprase array serving as a lookup table for the sum of event
+          weights per process id.
+        - py:attr:`xs_table`: A sparse array serving as a lookup table for cross sections of all
+          processes known to the config of the task, with keys being process ids.
     """
     # set to None for data
     if self.dataset_inst.is_data:
@@ -81,13 +87,21 @@ def normalization_weights_setup(self: Producer, inputs: dict) -> None:
     # load the selection stats
     self.selection_stats = inputs["selection_stats"].load(formatter="json")
 
-    # create a lookup table as a sparse array with all known processes
+    # for the lookup tables below, determine the maximum process id
     process_insts = [
         process_inst
         for process_inst, _, _ in self.config_inst.walk_processes()
         if process_inst.is_mc
     ]
     max_id = max(process_inst.id for process_inst in process_insts)
+
+    # create a event weight sum lookup table with all known processes
+    sum_weights_table = sp.sparse.lil_matrix((1, max_id + 1), dtype=np.float32)
+    for process_id, sum_weights in self.selection_stats["sum_mc_weight_per_process"].items():
+        sum_weights_table[0, int(process_id)] = sum_weights
+    self.sum_weights_table = sum_weights_table
+
+    # create a cross section lookup table with all known processes
     xs_table = sp.sparse.lil_matrix((1, max_id + 1), dtype=np.float32)
     for process_inst in process_insts:
         xs_table[0, process_inst.id] = process_inst.get_xsec(self.config_inst.campaign.ecm).nominal

--- a/ap/production/normalization.py
+++ b/ap/production/normalization.py
@@ -73,7 +73,7 @@ def normalization_weights_setup(self: Producer, inputs: dict) -> None:
     attributes:
 
         - py:attr:`selection_stats`: The stats dict loaded from the output of MergeSelectionsStats.
-        - py:attr:`sum_weights_table`: A sprase array serving as a lookup table for the sum of event
+        - py:attr:`sum_weights_table`: A sparse array serving as a lookup table for the sum of event
           weights per process id.
         - py:attr:`xs_table`: A sparse array serving as a lookup table for cross sections of all
           processes known to the config of the task, with keys being process ids.

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -248,10 +248,10 @@ def increment_stats(
         stats.setdefault("sum_mc_weight_selected_per_process", defaultdict(float))
         for p in np.unique(events.process_id):
             stats["sum_mc_weight_per_process"][int(p)] += ak.sum(
-                weights[events.process_id == p]
+                weights[events.process_id == p],
             )
             stats["sum_mc_weight_selected_per_process"][int(p)] += ak.sum(
-                weights[mask][events_sel.process_id == p]
+                weights[mask][events_sel.process_id == p],
             )
 
 


### PR DESCRIPTION
This is a rather small PR that fixes how sums of event weights are stored in the selection and applied when normalization weights are created.

Before, sums were stored as a single number per dataset. Now, they are stored per dataset and process id. Also, there a custom selector function now that handles the filing of the `stats` dictionary.

When creating the normalization weights, the sum of event weights is now obtain per event based on its process id, using a lookup table just like for the cross sections.