### PR TITLE
Allow dynamic plot functions.

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -33,7 +33,10 @@ jobs:
 
       - name: Cleanup 🧹
         if: always()
-        run: rm -rf "${AP_JOB_ID}"
+        run: |
+          pwd
+          ls -al
+          rm -rf "${AP_JOB_ID}"
 
   test:
     runs-on: [self-hosted]

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -34,8 +34,7 @@ jobs:
       - name: Cleanup 🧹
         if: always()
         run: |
-          pwd
-          ls -al
+          cd ..
           rm -rf "${AP_JOB_ID}"
 
   test:
@@ -65,7 +64,9 @@ jobs:
 
       - name: Cleanup 🧹
         if: always()
-        run: rm -rf "${AP_JOB_ID}"
+        run: |
+          cd ..
+          rm -rf "${AP_JOB_ID}"
 
   coverage:
     needs: test
@@ -105,4 +106,6 @@ jobs:
 
       - name: Cleanup 🧹
         if: always()
-        run: rm -rf "${AP_JOB_ID}"
+        run: |
+          cd ..
+          rm -rf "${AP_JOB_ID}"

--- a/ap/plotting/__init__.py
+++ b/ap/plotting/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/ap/plotting/plotter.py
+++ b/ap/plotting/plotter.py
@@ -180,7 +180,6 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
 
     # legend
     legend_kwargs = {
-        "title": "Processes",
         "ncol": 1,
         "loc": "upper right",
     }

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -51,9 +51,9 @@ def plot_variables(
     }
 
     # dummy since not implemented yet
-    MC_lines = False
-    if MC_lines:
-        plot_config["MC_lines"] = {
+    mc_lines = False
+    if mc_lines:
+        plot_config["mc_lines"] = {
             "method": "draw_from_stack",
             # "hist": h_lines_stack,
             # "kwargs": {"label": lines_label, "color": lines_colors, "stack": False, "histtype": "step"},

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -4,7 +4,8 @@
 Lightweight mixins task classes.
 """
 
-from typing import Union, Sequence, List, Set, Dict, Any
+import importlib
+from typing import Union, Sequence, List, Set, Dict, Any, Callable
 
 import law
 import luigi
@@ -715,6 +716,43 @@ class PlotMixin(AnalysisTask):
         description="a command to execute after the task has run to visualize plots right in the "
         "terminal; no default",
     )
+
+    def get_plot_func(self, func_name: str) -> Callable:
+        """
+        Returns a function, imported from a module given *func_name* which should have the format
+        ``<module_to_import>.<function_name>``.
+        """
+        # prepare names
+        if "." not in func_name:
+            raise ValueError(f"invalid func_id format: {func_name}")
+        module_id, name = func_name.rsplit(".", 1)
+
+        # import the module
+        try:
+            mod = importlib.import_module(module_id)
+        except ImportError as e:
+            raise ImportError(f"cannot import plot function {name} from module {module_id}: {e}")
+
+        # get the function
+        func = getattr(mod, name, None)
+        if func is None:
+            raise Exception(f"module {module_id} does not contain plot function {name}")
+
+        return func
+
+    def call_plot_func(self, func_name: str, **kwargs) -> Any:
+        """
+        Gets the plot function referred to by *func_name* via :py:meth:`get_plot_func`, calls it
+        with all *kwargs* and returns its result. *kwargss* are updated through the
+        :py:meth:`update_plot_kwargs` hook first.
+        """
+        return self.get_plot_func(func_name)(**(self.update_plot_kwargs(kwargs)))
+
+    def update_plot_kwargs(self, kwargs: dict) -> dict:
+        """
+        Hook to update keyword arguments *kwargs* used for plotting in :py:meth:`call_plot_func`.
+        """
+        return kwargs
 
 
 @law.decorator.factory(accept_generator=True)

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -743,7 +743,7 @@ class PlotMixin(AnalysisTask):
     def call_plot_func(self, func_name: str, **kwargs) -> Any:
         """
         Gets the plot function referred to by *func_name* via :py:meth:`get_plot_func`, calls it
-        with all *kwargs* and returns its result. *kwargss* are updated through the
+        with all *kwargs* and returns its result. *kwargs* are updated through the
         :py:meth:`update_plot_kwargs` hook first.
         """
         return self.get_plot_func(func_name)(**(self.update_plot_kwargs(kwargs)))

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -724,7 +724,7 @@ class PlotMixin(AnalysisTask):
         """
         # prepare names
         if "." not in func_name:
-            raise ValueError(f"invalid func_id format: {func_name}")
+            raise ValueError(f"invalid func_name format: {func_name}")
         module_id, name = func_name.rsplit(".", 1)
 
         # import the module

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+
 comment: false
+
 ignore:
   - "modules"
   - "docs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,13 @@
 coverage:
   status:
+    # main branch
     project:
+      default:
+        target: auto
+        informational: true
+
+    # PRs
+    patch:
       default:
         target: auto
         informational: true


### PR DESCRIPTION
This is a small PR that makes the actual plot functions that are called in `Plot(Shifted)Variables` dynamic. The functionality is added to the base `PlotMixin` and allows to dynamically import and call plot functions.

This way (and considering that the current `Plot(Shifted)Variables` tasks will be part of a "core" package), one can easily extend functionality in inheriting classes, e.g.

```python
class MyCustomPlot(PlotVariables):

    some_additional_label = luigi.Parameter()
    
    # different plot function than in PlotVariables with potentially different arguments
    plot_function_name = "myanalysis.plots.variables_plot"

    def update_plot_kwargs(self, kwargs):
        kwargs["some_additional_label"] = self.some_additional_label
        return kwargs
```