### PR TITLE
Feature/cutflow variables

### DIFF
--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -314,7 +314,7 @@ config_2018.set_aux("keep_columns", DotDict.wrap({
         "category_ids", "deterministic_seed",
     },
     "MergeSelectionMasks": {
-        "LHEWeight.originalXWGTUP", "normalization_weight", "process_id", "category_ids", "ht", "n_jet", "jet1_pt",
+        "LHEWeight.originalXWGTUP", "normalization_weight", "process_id", "category_ids", "cutflow.*",
     },
 }))
 

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -314,7 +314,7 @@ config_2018.set_aux("keep_columns", DotDict.wrap({
         "category_ids", "deterministic_seed",
     },
     "MergeSelectionMasks": {
-        "LHEWeight.originalXWGTUP", "normalization_weight", "process_id", "category_ids",
+        "LHEWeight.originalXWGTUP", "normalization_weight", "process_id", "category_ids", "ht", "n_jet", "jet1_pt",
     },
 }))
 

--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -74,7 +74,7 @@ for dataset_name in dataset_names:
 # default calibrator, selector, producer, ml model and inference model
 config_2018.set_aux("default_calibrator", "test")
 config_2018.set_aux("default_selector", "test")
-config_2018.set_aux("default_producer", "variables")
+config_2018.set_aux("default_producer", "features")
 config_2018.set_aux("default_ml_model", None)
 config_2018.set_aux("default_inference_model", "test")
 

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -107,7 +107,6 @@ def add_variables(config: od.Config) -> None:
         x_title=r"Jet 3 $\eta$",
     )
 
-
     # cutflow variables
     config.add_variable(
         name="cf_ht",

--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -106,3 +106,26 @@ def add_variables(config: od.Config) -> None:
         binning=(50, -2.5, 2.5),
         x_title=r"Jet 3 $\eta$",
     )
+
+
+    # cutflow variables
+    config.add_variable(
+        name="cf_ht",
+        expression="cutflow.ht",
+        binning=[0, 80, 120, 160, 200, 240, 280, 320, 400, 500, 600, 800],
+        unit="GeV",
+        x_title="HT",
+    )
+    config.add_variable(
+        name="cf_n_jet",
+        expression="cutflow.n_jet",
+        binning=(11, -0.5, 10.5),
+        x_title="Number of jets",
+    )
+    config.add_variable(
+        name="cf_jet1_pt",
+        expression="cutflow.jet1_pt",
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"Jet 1 $p_{T}$",
+    )

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -37,13 +37,13 @@ def plot_variables(
 
     # setup plotting configs
     plot_config = {
-        "MC_stack": {
+        "mc_stack": {
             "method": "draw_from_stack",
             "hist": h_mc_stack,
             "kwargs": {"norm": 1, "label": mc_labels, "color": mc_colors},
         },
-        "MC_uncert": {
-            "method": "draw_error_stairs",
+        "mc_uncert": {
+            "method": "draw_error_bands",
             "hist": h_mc,
             "kwargs": {"label": "MC stat. unc."},
             "ratio_kwargs": {"norm": h_mc.values()},

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -5,7 +5,9 @@ Scripts to create plots using the plotter
 """
 
 from collections import OrderedDict
-from typing import Sequence
+from typing import Sequence, Optional
+
+import law
 
 from ap.util import maybe_import
 from ap.plotting.plotter import plot_all
@@ -20,6 +22,7 @@ def plot_variables(
     hists: OrderedDict,
     config_inst: od.config,
     variable_inst: od.variable,
+    style_config: Optional[dict] = None,
 ) -> plt.Figure:
 
     # create the stack and a fake data hist using the smeared sum
@@ -67,7 +70,7 @@ def plot_variables(
             "ratio_kwargs": {"norm": h_mc.values()},
         }
 
-    style_config = {
+    default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
@@ -82,7 +85,10 @@ def plot_variables(
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
     }
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
     fig = plot_all(plot_config, style_config, ratio=True)
+
     return fig
 
 
@@ -91,6 +97,7 @@ def plot_shifted_variables(
     config_inst: od.config,
     process_inst: od.process,
     variable_inst: od.variable,
+    style_config: Optional[dict] = None,
 ) -> plt.Figure:
 
     # create the stack and the sum
@@ -110,7 +117,8 @@ def plot_shifted_variables(
             "ratio_kwargs": {"norm": norm, "color": ["black", "red", "blue"], "histtype": "step", "stack": False},
         },
     }
-    style_config = {
+
+    default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
@@ -128,13 +136,17 @@ def plot_shifted_variables(
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
     }
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
     fig = plot_all(plot_config, style_config, ratio=True)
+
     return fig
 
 
 def plot_cutflow(
     hists: OrderedDict,
     config_inst: od.config,
+    style_config: Optional[dict] = None,
 ) -> plt.Figure:
 
     mc_hists = [h for process_inst, h in hists.items() if process_inst.is_mc]
@@ -160,7 +172,7 @@ def plot_cutflow(
             },
         },
     }
-    style_config = {
+    default_style_config = {
         "ax_cfg": {
             "ylabel": "Selection efficiency",
             "xlabel": "Selection steps",
@@ -172,5 +184,8 @@ def plot_cutflow(
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
     }
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
     fig = plot_all(plot_config, style_config, ratio=False)
+
     return fig

--- a/ap/selection/test.py
+++ b/ap/selection/test.py
@@ -13,6 +13,8 @@ from ap.util import maybe_import
 from ap.columnar_util import set_ak_column, Route
 from ap.production.processes import process_ids
 
+from ap.columnar_util import EMPTY_FLOAT
+
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
@@ -94,13 +96,13 @@ def var_HT(self: Selector, events: ak.Array, **kwargs) -> ak.Array:
 
 @selector(
     uses={var_nJet, var_HT, "Jet.pt"},
-    produces={"n_jet", "ht", "jet1_pt"},
+    produces={"cutflow.n_jet", "cutflow.ht", "cutflow.jet1_pt"},
     exposed=True,
 )
 def cutflow_features(self: Selector, events: ak.Array, **kwargs) -> None:
-    set_ak_column(events, "n_jet", self[var_nJet](events))
-    set_ak_column(events, "ht", self[var_HT](events))
-    set_ak_column(events, "jet1_pt", Route("Jet.pt[:,0]").apply(events, -999))
+    set_ak_column(events, "cutflow.n_jet", self[var_nJet](events))
+    set_ak_column(events, "cutflow.ht", self[var_HT](events))
+    set_ak_column(events, "cutflow.jet1_pt", Route("Jet.pt[:,0]").apply(events, EMPTY_FLOAT))
 
 
 # selection for the main categories

--- a/ap/tasks/calibration.py
+++ b/ap/tasks/calibration.py
@@ -22,8 +22,11 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
 
     shifts = set(GetDatasetLFNs.shifts)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["lfns"] = GetDatasetLFNs.req(self)
 
         # add calibrator dependent requirements

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -41,8 +41,11 @@ class CreateCutflowHistograms(
         # dummy branch map
         return [None]
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super(CreateCutflowHistograms, self).workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["masks"] = MergeSelectionMasks.req(self, tree_index=0, _exclude={"branches"})
         return reqs
 
@@ -181,8 +184,11 @@ class PlotCutflow(
         # one category per branch
         return list(self.categories)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super(PlotCutflow, self).workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["hists"] = [
             CreateCutflowHistograms.req(
                 self,

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -147,7 +147,6 @@ class CreateCutflowHistograms(
         }
 
     def output(self):
-        print(self.variables)
         return {var: self.local_target(f"cutflow_hist__var_{var}.pickle") for var in self.variables}
 
     @law.decorator.safe_output
@@ -169,10 +168,8 @@ class CreateCutflowHistograms(
         aliases = self.shift_inst.x("column_aliases", {})
 
         # define a list of variables to create the histograms for
-        # TODO: for the moment, this is just the lhe_weight and ht but it could be extended
-        #       in the future and made configurable from the command line
-        variable_insts = [self.config_inst.get_variable(v)
-            for v in self.variables]
+        variable_insts = [self.config_inst.get_variable(v) for v in self.variables]
+
         # get the expression per variable and when it's a string, parse it to extract index lookups
         expressions = {}
         for variable_inst in variable_insts:
@@ -515,7 +512,7 @@ class PlotCutflowVariables(
 
                 # call the plot function
                 fig = self.call_plot_func(
-                    self.plot_funciton_name,
+                    self.plot_function_name,
                     hists=hists_step,
                     config_inst=self.config_inst,
                     variable_inst=variable_inst,

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -7,16 +7,17 @@ Tasks to be implemented: MergeSelectionMasks, PlotCutflow
 import functools
 from collections import OrderedDict
 
+import luigi
 import law
 
 from ap.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask, wrapper_factory
-from ap.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, SelectorStepsMixin, PlotMixin
+from ap.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, SelectorStepsMixin, VariablesMixin, PlotMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.plotting import ProcessPlotBase
 from ap.tasks.selection import SelectEvents
 from ap.production import Producer
-from ap.util import dev_sandbox, ensure_proxy
-from ap.plotting.variables import plot_cutflow
+from ap.util import dev_sandbox, ensure_proxy, DotDict
+from ap.plotting.variables import plot_cutflow, plot_variables
 
 
 class MergeSelectionMasks(
@@ -167,10 +168,10 @@ class CreateCutflowHistograms(
         aliases = self.shift_inst.x("column_aliases", {})
 
         # define a list of variables to create the histograms for
-        # TODO: for the moment, this is just the lhe_weight but it could be extended in the future
-        #       and made configurable from the command line
-        variable_insts = [self.config_inst.get_variable("lhe_weight")]
-
+        # TODO: for the moment, this is just the lhe_weight and ht but it could be extended
+        #       in the future and made configurable from the command line
+        variable_insts = [self.config_inst.get_variable(v)
+            for v in ["lhe_weight", "ht"]]
         # get the expression per variable and when it's a string, parse it to extract index lookups
         expressions = {}
         for variable_inst in variable_insts:
@@ -213,7 +214,6 @@ class CreateCutflowHistograms(
 
                 for variable_inst in variable_insts:
                     var_name = variable_inst.name
-
                     # helper to build the point for filling, except for the step which does
                     # not support broadcasting
                     def get_point(mask=Ellipsis):
@@ -232,6 +232,7 @@ class CreateCutflowHistograms(
 
                     # fill all other steps
                     steps = self.selector_steps or arr.steps.fields
+
                     mask = True
                     for step in steps:
                         if step not in arr.steps.fields:
@@ -369,3 +370,133 @@ PlotCutflowWrapper = wrapper_factory(
     require_cls=PlotCutflow,
     enable=["configs", "skip_configs", "shifts", "skip_shifts"],
 )
+
+
+class PlotCutflowVariables(
+    ShiftTask,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    VariablesMixin,
+    ProcessPlotBase,
+    law.LocalWorkflow,
+    HTCondorWorkflow,
+):
+
+    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
+
+    plot_steps = luigi.BoolParameter(
+        default=True,
+        significant=False,
+        description="boolean; if False, plots are only produced after the final selector step;"
+        "default: True",
+    )
+
+    shifts = set(CreateCutflowHistograms.shifts)
+
+    selector_steps_order_sensitive = True
+
+    def create_branch_map(self):
+        return [
+            DotDict({"category": cat_name, "variable": var_name})
+            for cat_name in sorted(self.categories)
+            for var_name in sorted(self.variables)
+        ]
+
+    def workflow_requires(self):
+        reqs = super(PlotCutflowVariables, self).workflow_requires()
+        reqs["hists"] = [
+            CreateCutflowHistograms.req(self, dataset=d, _exclude={"branches"})
+            for d in self.datasets
+        ]
+        return reqs
+
+    def requires(self):
+        return {
+            d: CreateCutflowHistograms.req(self, dataset=d, branch=0)
+            for d in self.datasets
+        }
+
+    def output(self):
+        b = self.branch_data
+        outputs = {
+            step: self.local_target(f"plot__step_{step}__cat_{b.category}__var_{b.variable}.pdf")
+            for step in ["Initial"] + list(self.selector_steps)
+        }
+        return outputs
+
+    @PlotMixin.view_output_plots
+    def run(self):
+        import hist
+
+        # prepare config objects
+        variable_inst = self.config_inst.get_variable(self.branch_data.variable)
+        category_inst = self.config_inst.get_category(self.branch_data.category)
+        leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
+        process_insts = list(map(self.config_inst.get_process, self.processes))
+        sub_process_insts = {
+            proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
+            for proc in process_insts
+        }
+
+        # histogram data per process
+        hists = {}
+
+        with self.publish_step(f"plotting {variable_inst.name} in {category_inst.name}"):
+            for dataset, inp in self.input().items():
+                dataset_inst = self.config_inst.get_dataset(dataset)
+                h_in = inp.load(formatter="pickle")[variable_inst.name]
+
+                # sanity checks
+                n_shifts = len(h_in.axes["shift"])
+                if n_shifts != 1:
+                    raise Exception(f"shift axis is supposed to only contain 1 bin, found {n_shifts}")
+
+                # loop and extract one histogram per process
+                for process_inst in process_insts:
+                    # skip when the dataset is already known to not contain any sub process
+                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                        continue
+
+                    # work on a copy
+                    h = h_in.copy()
+
+                    # axis selections
+                    h = h[{
+                        "process": [
+                            hist.loc(p.id)
+                            for p in sub_process_insts[process_inst]
+                            if p.id in h.axes["process"]
+                        ],
+                        "category": [
+                            hist.loc(c.id)
+                            for c in leaf_category_insts
+                            if c.id in h.axes["category"]
+                        ],
+                    }]
+
+                    # axis reductions
+                    h = h[{"process": sum, "category": sum, "shift": sum}]
+
+                    # add the histogram
+                    if process_inst in hists:
+                        hists[process_inst] += h
+                    else:
+                        hists[process_inst] = h
+
+            # there should be hists to plot
+            if not hists:
+                raise Exception("no histograms found to plot")
+            if self.plot_steps:
+                steps = (["Initial"] + list(self.selector_steps))
+            else:
+                steps = [self.selector_steps[-1]]
+            for step in steps:
+
+                # sort hists by process order
+                hists_step = OrderedDict(
+                    (process_inst, hists[process_inst][{"step": step}])
+                    for process_inst in sorted(hists, key=process_insts.index)
+                )
+                fig = plot_variables(hists_step, self.config_inst, variable_inst)
+
+                self.output()[step].dump(fig, formatter="mpl")

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -272,6 +272,8 @@ class PlotCutflow(
 
     shifts = set(CreateCutflowHistograms.shifts)
 
+    plot_function_name = "ap.plotting.variables.plot_cutflow"
+
     selector_steps_order_sensitive = True
 
     def create_branch_map(self):
@@ -363,8 +365,14 @@ class PlotCutflow(
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
-            fig = plot_cutflow(hists, self.config_inst)
+            # call the plot function
+            fig = self.call_plot_func(
+                self.plot_function_name,
+                hists=hists,
+                config_inst=self.config_inst,
+            )
 
+            # save the plot
             self.output().dump(fig, formatter="mpl")
 
 
@@ -395,6 +403,9 @@ class PlotCutflowVariables(
     )
 
     shifts = set(CreateCutflowHistograms.shifts)
+
+    # default plot function
+    plot_function_name = "ap.plotting.variables.plot_variables"
 
     selector_steps_order_sensitive = True
 
@@ -489,6 +500,8 @@ class PlotCutflowVariables(
             # there should be hists to plot
             if not hists:
                 raise Exception("no histograms found to plot")
+
+            # produce plots for all steps
             if self.plot_steps:
                 steps = (["Initial"] + list(self.selector_steps))
             else:
@@ -500,6 +513,14 @@ class PlotCutflowVariables(
                     (process_inst, hists[process_inst][{"step": step}])
                     for process_inst in sorted(hists, key=process_insts.index)
                 )
-                fig = plot_variables(hists_step, self.config_inst, variable_inst)
 
+                # call the plot function
+                fig = self.call_plot_func(
+                    self.plot_funciton_name,
+                    hists=hists_step,
+                    config_inst=self.config_inst,
+                    variable_inst=variable_inst,
+                )
+
+                # save the plot
                 self.output()[step].dump(fig, formatter="mpl")

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -17,7 +17,6 @@ from ap.tasks.plotting import ProcessPlotBase
 from ap.tasks.selection import SelectEvents
 from ap.production import Producer
 from ap.util import dev_sandbox, ensure_proxy, DotDict
-from ap.plotting.variables import plot_cutflow, plot_variables
 
 
 class MergeSelectionMasks(

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -548,6 +548,8 @@ class VariablesMixin(ConfigTask):
         "all variables of the config; empty default",
     )
 
+    default_variables = None
+
     @classmethod
     def modify_param_values(cls, params):
         params = super().modify_param_values(params)
@@ -558,7 +560,12 @@ class VariablesMixin(ConfigTask):
 
         # resolve variables
         if "variables" in params:
+            # when empty and default variables are defined, use them instead
+            if not params["variables"] and cls.default_variables:
+                params["variables"] = tuple(cls.default_variables)
+
             if params["variables"]:
+                # resolve variable names
                 variables = cls.find_config_objects(
                     params["variables"],
                     config_inst,
@@ -566,6 +573,7 @@ class VariablesMixin(ConfigTask):
                     config_inst.x("variable_groups", {}),
                 )
             else:
+                # fallback to using all known variables
                 variables = config_inst.variables.names()
             params["variables"] = tuple(variables)
 

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -35,8 +35,10 @@ class CreateHistograms(
 
     shifts = MergeReducedEvents.shifts | ProduceColumns.shifts
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super(CreateHistograms, self).workflow_requires()
+        if only_super:
+            return reqs
 
         reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
         if not self.pilot:
@@ -246,8 +248,10 @@ class MergeShiftedHistograms(
     effective_shift = None
     allow_empty_shift = True
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super(MergeShiftedHistograms, self).workflow_requires()
+        if only_super:
+            return reqs
 
         # add nominal and both directions per shift source
         for shift in ["nominal"] + self.shifts:

--- a/ap/tasks/inference.py
+++ b/ap/tasks/inference.py
@@ -32,8 +32,10 @@ class CreateDatacards(
     def create_branch_map(self):
         return list(self.inference_model_inst.categories)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
 
         # simply require the requirements of all branch tasks right now
         reqs["merged_hists"] = set(sum((

--- a/ap/tasks/ml.py
+++ b/ap/tasks/ml.py
@@ -40,8 +40,10 @@ class PrepareMLEvents(
                 f"{self.__class__.__name__}",
             )
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
 
         reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
         if not self.pilot and self.producers:
@@ -288,8 +290,10 @@ class MLEvaluation(
         # set the sandbox
         self.sandbox = self.ml_model_inst.sandbox(self)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super(MLEvaluation, self).workflow_requires()
+        if only_super:
+            return reqs
 
         reqs["models"] = [MLTraining.req(self, fold=f) for f in range(self.ml_model_inst.folds)]
 

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -15,7 +15,7 @@ from ap.tasks.framework.mixins import (
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from ap.util import DotDict, dev_sandbox
+from ap.util import DotDict
 
 
 class ProcessPlotBase(
@@ -46,7 +46,7 @@ class PlotVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
     shifts = set(MergeHistograms.shifts)
 
@@ -178,7 +178,7 @@ class PlotShiftedVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
     # default plot function
     plot_function_name = "ap.plotting.variables.plot_shifted_variables"

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -15,7 +15,7 @@ from ap.tasks.framework.mixins import (
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from ap.util import DotDict
+from ap.util import DotDict, dev_sandbox
 
 
 class ProcessPlotBase(
@@ -46,7 +46,7 @@ class PlotVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(MergeHistograms.shifts)
 
@@ -60,8 +60,11 @@ class PlotVariables(
             for var_name in sorted(self.variables)
         ]
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["merged_hists"] = self.requires_from_branch()
         return reqs
 
@@ -175,7 +178,7 @@ class PlotShiftedVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
     # default plot function
     plot_function_name = "ap.plotting.variables.plot_shifted_variables"
@@ -193,8 +196,11 @@ class PlotShiftedVariables(
             for source in sorted(self.shift_sources)
         ]
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["merged_hists"] = self.requires_from_branch()
         return reqs
 

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -26,8 +26,10 @@ class ProduceColumns(
 
     shifts = set(MergeReducedEvents.shifts)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
 
         reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
         reqs["producer"] = self.producer_inst.run_requires()

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -27,8 +27,11 @@ class ReduceEvents(DatasetTask, SelectorStepsMixin, CalibratorsMixin, law.LocalW
 
     shifts = CalibrateEvents.shifts | SelectEvents.shifts
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["lfns"] = GetDatasetLFNs.req(self)
         if not self.pilot:
             reqs["calibrations"] = [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators]

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -26,9 +26,12 @@ class SelectEvents(DatasetTask, SelectorMixin, CalibratorsMixin, law.LocalWorkfl
 
     shifts = set(CalibrateEvents.shifts)
 
-    def workflow_requires(self):
+    def workflow_requires(self, only_super: bool = False):
         # workflow super classes might already define requirements, so extend them
         reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
         reqs["lfns"] = GetDatasetLFNs.req(self)
         if not self.pilot:
             reqs["calib"] = [CalibrateEvents.req(self, calibrator=c) for c in self.calibrators]

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -13,6 +13,7 @@ from ap.tasks.framework.mixins import CalibratorsMixin, SelectorMixin
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.external import GetDatasetLFNs
 from ap.tasks.calibration import CalibrateEvents
+from ap.production import Producer
 from ap.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
 
 
@@ -218,5 +219,103 @@ class MergeSelectionStats(DatasetTask, SelectorMixin, CalibratorsMixin, law.task
 MergeSelectionStatsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
     require_cls=MergeSelectionStats,
+    enable=["configs", "skip_configs", "datasets", "skip_datasets", "shifts", "skip_shifts"],
+)
+
+
+class MergeSelectionMasks(
+    DatasetTask,
+    SelectorMixin,
+    CalibratorsMixin,
+    law.tasks.ForestMerge,
+    HTCondorWorkflow,
+):
+
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+
+    shifts = set(SelectEvents.shifts)
+
+    # recursively merge 8 files into one
+    merge_factor = 8
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # store the normalization weight producer
+        self.norm_weight_producer = Producer.get_cls("normalization_weights")(
+            inst_dict=self.get_producer_kwargs(self),
+        )
+
+    def create_branch_map(self):
+        # DatasetTask implements a custom branch map, but we want to use the one in ForestMerge
+        return law.tasks.ForestMerge.create_branch_map(self)
+
+    def merge_workflow_requires(self):
+        return {
+            "selection": SelectEvents.req(self, _exclude={"branches"}),
+            "normalization": self.norm_weight_producer.run_requires(),
+        }
+
+    def merge_requires(self, start_branch, end_branch):
+        return {
+            "selection": [SelectEvents.req(self, branch=b) for b in range(start_branch, end_branch)],
+            "normalization": self.norm_weight_producer.run_requires(),
+        }
+
+    def trace_merge_workflow_inputs(self, inputs):
+        return super().trace_merge_workflow_inputs(inputs["selection"])
+
+    def trace_merge_inputs(self, inputs):
+        return super().trace_merge_inputs(inputs["selection"])
+
+    def merge_output(self):
+        return self.local_target("masks.parquet")
+
+    def merge(self, inputs, output):
+        # in the lowest (leaf) stage, zip selection results with additional columns first
+        if self.is_leaf():
+            # create a temp dir for saving intermediate files
+            tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
+            tmp_dir.touch()
+            inputs = self.zip_results_and_columns(inputs, tmp_dir)
+
+        law.pyarrow.merge_parquet_task(self, inputs, output, local=True)
+
+    def zip_results_and_columns(self, inputs, tmp_dir):
+        import awkward as ak
+        from ap.columnar_util import RouteFilter, sorted_ak_to_parquet
+
+        chunks = []
+
+        # setup the normalization weights producer
+        self.norm_weight_producer.run_setup(self.input()["forest_merge"]["normalization"])
+
+        # get columns to keep
+        keep_columns = set(self.config_inst.x.keep_columns[self.task_family])
+        route_filter = RouteFilter(keep_columns)
+
+        for inp in inputs:
+            events = inp["columns"].load(formatter="awkward")
+            steps = inp["results"].load(formatter="awkward").steps
+
+            # add normalization weight
+            self.norm_weight_producer(events)
+
+            # remove columns
+            events = route_filter(events)
+
+            # zip them
+            out = ak.zip({"steps": steps, "events": events})
+
+            chunk = tmp_dir.child(f"tmp_{inp['results'].basename}", type="f")
+            chunks.append(chunk)
+            sorted_ak_to_parquet(out, chunk.path)
+
+        return chunks
+
+
+MergeSelectionMasksWrapper = wrapper_factory(
+    base_cls=AnalysisTask,
+    require_cls=MergeSelectionMasks,
     enable=["configs", "skip_configs", "datasets", "skip_datasets", "shifts", "skip_shifts"],
 )

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,9 @@ coverage:
 
 comment: false
 
+github_checks:
+  annotations: false
+
 ignore:
   - "modules"
   - "docs"


### PR DESCRIPTION
This rather small PR adds a new task `PlotCutflowVariables`, which allows plotting variables using the output from `CreateCutflowHistograms`. The `CreateCutflowHistograms` task is now also a `VariablesMixin` and returns one output file per variable.
The variables which one wants to plot need to be saved in `SelectEvents` via `set_ak_column` in the selector function and added to the `keep_columns` aux in the config.
The `PlotCutflowVariables` adds one new parameter, `plot_steps`, which is a boolean to handle whether to create plots after each individual selection step or only after the final selection step.

Command for testing:
`law run PlotCutflowVariables --version test --variables cf_ht,cf_n_jet --processes tt_sl,st_tchannel, --categories incl --selector-steps Jet,Lepton,Deepjet --plot-steps True --workers 6`