### PR TITLE
Adapt plots to mpl version in venv_columnar.

### DIFF
--- a/ap/config/analysis_st.py
+++ b/ap/config/analysis_st.py
@@ -74,7 +74,7 @@ for dataset_name in dataset_names:
 # default calibrator, selector, producer, ml model and inference model
 config_2018.set_aux("default_calibrator", "test")
 config_2018.set_aux("default_selector", "test")
-config_2018.set_aux("default_producer", "variables")
+config_2018.set_aux("default_producer", "features")
 config_2018.set_aux("default_ml_model", None)
 config_2018.set_aux("default_inference_model", "test")
 

--- a/ap/plotting/plotter.py
+++ b/ap/plotting/plotter.py
@@ -14,7 +14,7 @@ plt = maybe_import("matplotlib.pyplot")
 mplhep = maybe_import("mplhep")
 
 
-def draw_error_stairs(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
+def draw_error_bands(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
     # compute relative errors
     rel_error = h.variances()**0.5 / h.values()
     rel_error[np.isnan(rel_error)] = 0.0
@@ -120,7 +120,7 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
     # available plot methods mapped to their names
     plot_methods = {  # noqa
         func.__name__: func
-        for func in [draw_error_stairs, draw_from_stack, draw_from_hist, draw_errorbars]
+        for func in [draw_error_bands, draw_from_stack, draw_from_hist, draw_errorbars]
     }
 
     plt.style.use(mplhep.style.CMS)

--- a/ap/plotting/plotter.py
+++ b/ap/plotting/plotter.py
@@ -4,7 +4,7 @@
 Generalized plotting functions to create plots from hist histograms
 """
 
-from typing import Optional, Sequence
+from typing import Sequence
 
 from ap.util import maybe_import, test_float
 
@@ -14,31 +14,32 @@ plt = maybe_import("matplotlib.pyplot")
 mplhep = maybe_import("mplhep")
 
 
-def draw_error_stairs(ax: plt.Axes, h: hist.Hist, kwargs: Optional[dict] = None) -> None:
-    if kwargs is None:
-        kwargs = {}
-    norm = kwargs.pop("norm", 1)
-    values = h.values() / norm
-    error = np.sqrt(h.variances()) / norm
+def draw_error_stairs(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
+    # compute relative errors
+    rel_error = h.variances()**0.5 / h.values()
+    rel_error[np.isnan(rel_error)] = 0.0
+
+    # compute the baseline
+    # fill 1 in places where both numerator and denominator are 0, and 0 for remaining nan's
+    baseline = h.values() / norm
+    baseline[(h.values() == 0) & (norm == 0)] = 1.0
+    baseline[np.isnan(baseline)] = 0.0
+
     defaults = {
-        "edges": h.axes[0].edges,
-        "baseline": values - error,
-        "values": values + error,
+        "x": h.axes[0].centers,
+        "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
+        "height": baseline * 2 * rel_error,
+        "bottom": baseline * (1 - rel_error),
         "hatch": "///",
         "facecolor": "none",
         "linewidth": 0,
         "color": "black",
     }
     defaults.update(kwargs)
-    ax.stairs(**defaults)
+    ax.bar(**defaults)
 
 
-def draw_from_stack(ax: plt.Axes, h: hist.Stack, kwargs: Optional[dict] = None) -> None:
-    if kwargs is None:
-        kwargs = {}
-
-    norm = kwargs.pop("norm", 1)
-
+def draw_from_stack(ax: plt.Axes, h: hist.Stack, norm: float = 1.0, **kwargs) -> None:
     # check if norm is a number
     if test_float(norm):
         h = hist.Stack(*[i / norm for i in h])
@@ -46,13 +47,13 @@ def draw_from_stack(ax: plt.Axes, h: hist.Stack, kwargs: Optional[dict] = None) 
         if not isinstance(norm, Sequence) and not isinstance(norm, np.ndarray):
             raise TypeError(f"norm must be either a number, sequence or np.ndarray, not a {type(norm)}")
         norm = np.array(norm)
-        # 1 normalization factor/array per histogram
         if len(norm) == len(h):
+            # 1 normalization factor/array per histogram
             h = hist.Stack(*[h[i] / norm[i] for i in range(len(h))])
-        # same normalization for each histogram
-        # edge case N_bins = N_histograms not considered :(
-        # solution: transform norm -> [norm]*len(h)
         else:
+            # same normalization for each histogram
+            # edge case N_bins = N_histograms not considered :(
+            # solution: transform norm -> [norm]*len(h)
             h = hist.Stack(*[i / norm for i in h])
 
     defaults = {
@@ -64,11 +65,7 @@ def draw_from_stack(ax: plt.Axes, h: hist.Stack, kwargs: Optional[dict] = None) 
     h.plot(**defaults)
 
 
-def draw_from_hist(ax: plt.Axes, h: hist.Hist, kwargs: Optional[dict] = None) -> None:
-    if kwargs is None:
-        kwargs = {}
-
-    norm = kwargs.pop("norm", 1)
+def draw_from_hist(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
     h = h / norm
     defaults = {
         "ax": ax,
@@ -79,15 +76,11 @@ def draw_from_hist(ax: plt.Axes, h: hist.Hist, kwargs: Optional[dict] = None) ->
     h.plot1d(**defaults)
 
 
-def draw_errorbars(ax: plt.Axes, h: hist.Hist, kwargs: Optional[dict] = None) -> None:
-    if kwargs is None:
-        kwargs = {}
-
-    norm = kwargs.pop("norm", 1)
+def draw_errorbars(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
     values = h.values() / norm
     variances = np.sqrt(h.variances()) / norm
     # compute asymmetric poisson errors for data
-    # TODO: passing the output of poisson_interval to as yerr to mpl.plothist leads to
+    # TODO: passing the output of poisson_interval as yerr to mpl.plothist leads to
     #       buggy error bars and the documentation is clearly wrong (mplhep 0.3.12,
     #       hist 2.4.0), so adjust the output to make up for that, but maybe update or
     #       remove the next lines if this is fixed to not correct it "twice"
@@ -148,12 +141,12 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
             raise ValueError("No histogram(s) given in plot_cfg entry {key}")
         hist = cfg["hist"]
         kwargs = cfg.get("kwargs", {})
-        plot_methods[method](ax, hist, kwargs)
+        plot_methods[method](ax, hist, **kwargs)
 
         if ratio and "ratio_kwargs" in cfg:
             # take ratio_method if the ratio plot requires a different plotting method
             method = cfg.get("ratio_method", method)
-            plot_methods[method](rax, hist, cfg["ratio_kwargs"])
+            plot_methods[method](rax, hist, **cfg["ratio_kwargs"])
 
     # axis styling
     ax_kwargs = {
@@ -170,13 +163,14 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
         # hard-coded line at 1
         rax.axhline(y=1.0, linestyle="dashed", color="gray")
         rax_kwargs = {
-            "ylim": (0.75, 1.25),
+            "ylim": (0.72, 1.28),
             "ylabel": "Ratio",
             "xlabel": "Variable",
             "yscale": "linear",
         }
         rax_kwargs.update(style_config.get("rax_cfg", {}))
         rax.set(**rax_kwargs)
+        fig.align_ylabels()
 
     # legend
     legend_kwargs = {
@@ -188,7 +182,7 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
 
     cms_label_kwargs = {
         "ax": ax,
-        "label": "Work in Progress",
+        "llabel": "Work in progress",
         "fontsize": 22,
     }
     cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -37,12 +37,12 @@ def plot_variables(
 
     # setup plotting configs
     plot_config = {
-        "MC_stack": {
+        "mc_stack": {
             "method": "draw_from_stack",
             "hist": h_mc_stack,
             "kwargs": {"norm": 1, "label": mc_labels, "color": mc_colors},
         },
-        "MC_uncert": {
+        "mc_uncert": {
             "method": "draw_error_stairs",
             "hist": h_mc,
             "kwargs": {"label": "MC stat. unc."},

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -43,7 +43,7 @@ def plot_variables(
             "kwargs": {"norm": 1, "label": mc_labels, "color": mc_colors},
         },
         "mc_uncert": {
-            "method": "draw_error_stairs",
+            "method": "draw_error_bands",
             "hist": h_mc,
             "kwargs": {"label": "MC stat. unc."},
             "ratio_kwargs": {"norm": h_mc.values()},

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -15,7 +15,7 @@ from ap.tasks.framework.mixins import (
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from ap.util import DotDict
+from ap.util import DotDict, dev_sandbox
 
 
 class ProcessPlotBase(
@@ -46,7 +46,7 @@ class PlotVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(MergeHistograms.shifts)
 
@@ -175,7 +175,7 @@ class PlotShiftedVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
     # default plot function
     plot_function_name = "ap.plotting.variables.plot_shifted_variables"


### PR DESCRIPTION
This PR adapts one part in the plotting code, `ax.stairs`, to be compatible with the mpl version in the current `venv_columnar`. `ax.bars` can do the same, though with a different parametrization of the stat. error bars.

In addition, this PR changes the plot functions from expecting `kwargs` in a single dict, to dynamic `**kwargs`. This way, defaults can be defined as `def func(my_value_with_deefault=123, **kwargs)`, and this avoids the need for having to copy the kwargs to prevent results from in-place operations to show up in calling contexts as well.

Closes #26.