### PR TITLE
First set of core generalizations

### DIFF
--- a/ap/tasks/calibration.py
+++ b/ap/tasks/calibration.py
@@ -46,10 +46,11 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
         return reqs
 
     def output(self):
-        return self.local_target(f"calib_{self.branch}.parquet")
+        return self.target(f"calib_{self.branch}.parquet")
 
-    @law.decorator.safe_output
     @ensure_proxy
+    @law.decorator.localize(input=False, output=True)
+    @law.decorator.safe_output
     def run(self):
         from ap.columnar_util import (
             Route, RouteFilter, ChunkedReader, mandatory_coffea_columns, sorted_ak_to_parquet,

--- a/ap/tasks/calibration.py
+++ b/ap/tasks/calibration.py
@@ -22,12 +22,15 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
 
     shifts = set(GetDatasetLFNs.shifts)
 
+    # default upstream dependency task classes
+    dep_GetDatasetLFNs = GetDatasetLFNs
+
     def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
         if only_super:
             return reqs
 
-        reqs["lfns"] = GetDatasetLFNs.req(self)
+        reqs["lfns"] = self.dep_GetDatasetLFNs.req(self)
 
         # add calibrator dependent requirements
         reqs["calibrator"] = self.calibrator_inst.run_requires()
@@ -35,7 +38,7 @@ class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorW
         return reqs
 
     def requires(self):
-        reqs = {"lfns": GetDatasetLFNs.req(self)}
+        reqs = {"lfns": self.dep_GetDatasetLFNs.req(self)}
 
         # add calibrator dependent requirements
         reqs["calibrator"] = self.calibrator_inst.run_requires()

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -17,7 +17,7 @@ from ap.tasks.framework.mixins import (
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.plotting import ProcessPlotBase
 from ap.tasks.selection import MergeSelectionMasks
-from ap.util import dev_sandbox, ensure_proxy, DotDict
+from ap.util import dev_sandbox, DotDict
 
 
 class CreateCutflowHistograms(

--- a/ap/tasks/external.py
+++ b/ap/tasks/external.py
@@ -38,10 +38,10 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
     def single_output(self):
         # required by law.tasks.TransferLocalFile
         h = law.util.create_hash(list(sorted(self.dataset_info_inst.keys)))
-        return self.local_target(f"lfns_{h}.json")
+        return self.target(f"lfns_{h}.json")
 
-    @law.decorator.safe_output
     @ensure_proxy
+    @law.decorator.safe_output
     def run(self):
         lfns = []
         for key in sorted(self.dataset_info_inst.keys):
@@ -200,7 +200,7 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
 
     def single_output(self):
         # required by law.tasks.TransferLocalFile
-        return self.local_target(f"externals_{self.files_hash}.tgz")
+        return self.target(f"externals_{self.files_hash}.tgz")
 
     @law.decorator.safe_output
     def run(self):
@@ -261,7 +261,7 @@ class CreatePileupWeights(ConfigTask):
         return self.dep_BundleExternalFiles.req(self)
 
     def output(self):
-        return self.local_target(f"weights_from_{self.data_mode}.json")
+        return self.target(f"weights_from_{self.data_mode}.json")
 
     @law.decorator.safe_output
     def run(self):

--- a/ap/tasks/external.py
+++ b/ap/tasks/external.py
@@ -254,8 +254,11 @@ class CreatePileupWeights(ConfigTask):
     )
     version = None
 
+    # default upstream dependency task classes
+    dep_BundleExternalFiles = BundleExternalFiles
+
     def requires(self):
-        return BundleExternalFiles.req(self)
+        return self.dep_BundleExternalFiles.req(self)
 
     def output(self):
         return self.local_target(f"weights_from_{self.data_mode}.json")

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -33,6 +33,10 @@ class BaseTask(law.Task):
 
 class AnalysisTask(BaseTask, law.SandboxTask):
 
+    analysis = luigi.Parameter(
+        default="analysis_st",
+        description="name of the analysis; default: 'analysis_st'",
+    )
     version = luigi.Parameter(description="mandatory version that is encoded into output paths")
 
     allow_empty_sandbox = True
@@ -40,9 +44,6 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
     local_workflow_require_branches = False
     output_collection_cls = law.SiblingFileCollection
-
-    # hard-coded analysis name, could be changed to a parameter
-    analysis = "analysis_st"
 
     # defaults for targets
     default_store = "$AP_STORE_LOCAL"
@@ -54,7 +55,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         params = super().modify_param_values(params)
 
         # store a reference to the analysis inst
-        params["analysis_inst"] = cls.get_analysis_inst(cls.analysis)
+        if "analysis" in params:
+            params["analysis_inst"] = cls.get_analysis_inst(params["analysis"])
 
         return params
 
@@ -120,7 +122,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     def get_array_function_kwargs(cls, task=None, **params):
         return {
             "task": task,
-            "analysis_inst": task.analysis_inst if task else cls.get_analysis_inst(cls.analysis),
+            "analysis_inst": task.analysis_inst if task else cls.get_analysis_inst(params["analysis"]),
         }
 
     @classmethod

--- a/ap/tasks/framework/base.py
+++ b/ap/tasks/framework/base.py
@@ -16,6 +16,11 @@ import law
 import order as od
 
 
+default_analysis = law.config.get_expanded("analysis", "default_analysis")
+default_config = law.config.get_expanded("analysis", "default_config")
+default_dataset = law.config.get_expanded("analysis", "default_dataset")
+
+
 class OutputLocation(enum.Enum):
     """
     Output location flag.
@@ -34,8 +39,8 @@ class BaseTask(law.Task):
 class AnalysisTask(BaseTask, law.SandboxTask):
 
     analysis = luigi.Parameter(
-        default="analysis_st",
-        description="name of the analysis; default: 'analysis_st'",
+        default=default_analysis,
+        description=f"name of the analysis; default: '{default_analysis}'",
     )
     version = luigi.Parameter(description="mandatory version that is encoded into output paths")
 
@@ -326,13 +331,15 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         # forward to correct function
         if location[0] == OutputLocation.local:
-            if len(location) > 1:
-                kwargs.setdefault("store", location[1])
+            # get other options
+            (store,) = (location[1:] + [None])[:1]
+            kwargs.setdefault("store", store)
             return self.local_target(*path, **kwargs)
 
         elif location[0] == OutputLocation.wlcg:
-            if len(location) > 1:
-                kwargs.setdefault("fs", location[1])
+            # get other options
+            (fs,) = (location[1:] + [None])[:1]
+            kwargs.setdefault("fs", fs)
             return self.wlcg_target(*path, **kwargs)
 
         raise Exception(f"cannot determine output location based on '{location}'")
@@ -341,8 +348,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 class ConfigTask(AnalysisTask):
 
     config = luigi.Parameter(
-        default="run2_pp_2018",
-        description="name of the analysis config to use; default: 'run2_pp_2018'",
+        default=default_config,
+        description=f"name of the analysis config to use; default: '{default_config}'",
     )
 
     @classmethod
@@ -504,8 +511,8 @@ class ShiftTask(ConfigTask):
 class DatasetTask(ShiftTask):
 
     dataset = luigi.Parameter(
-        default="st_tchannel_t",
-        description="name of the dataset to process; default: 'st_tchannel_t'",
+        default=default_dataset,
+        description=f"name of the dataset to process; default: '{default_dataset}'",
     )
 
     file_merging = None

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -782,8 +782,12 @@ def view_output_plots(fn, opts, task, *args, **kwargs):
                 continue
             if not getattr(output, "path", None):
                 continue
-            if output.path.endswith((".pdf", ".png")) and output.path not in view_paths:
-                view_paths.append(output.path)
+            if output.path.endswith((".pdf", ".png")):
+                if not isinstance(output, law.LocalTarget):
+                    task.logger.warning(f"cannot show non-local plot at '{output.path}'")
+                    continue
+                elif output.path not in view_paths:
+                    view_paths.append(output.path)
 
         # loop through paths and view them
         for path in view_paths:

--- a/ap/tasks/framework/remote.py
+++ b/ap/tasks/framework/remote.py
@@ -163,6 +163,7 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
     task_namespace = None
 
     default_wlcg_fs = "wlcg_fs_software"
+    default_output_location = "wlcg"
 
     def get_repo_path(self):
         # required by BundleGitRepository
@@ -170,7 +171,7 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
 
     def single_output(self):
         repo_base = os.path.basename(self.get_repo_path())
-        return self.wlcg_target(f"{repo_base}.{self.checksum}.tgz")
+        return self.target(f"{repo_base}.{self.checksum}.tgz")
 
     def get_file_pattern(self):
         path = os.path.expandvars(os.path.expanduser(self.single_output().path))
@@ -202,6 +203,7 @@ class BundleSoftware(AnalysisTask, law.tasks.TransferLocalFile):
     version = None
 
     default_wlcg_fs = "wlcg_fs_software"
+    default_output_location = "wlcg"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -233,7 +235,7 @@ class BundleSoftware(AnalysisTask, law.tasks.TransferLocalFile):
         return self._checksum
 
     def single_output(self):
-        return self.wlcg_target(f"software.{self.checksum}.tgz")
+        return self.target(f"software.{self.checksum}.tgz")
 
     def get_file_pattern(self):
         path = os.path.expandvars(os.path.expanduser(self.single_output().path))
@@ -281,6 +283,7 @@ class BundleCMSSW(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLocalFile
     task_namespace = None
     exclude = "^src/tmp"
     default_wlcg_fs = "wlcg_fs_software"
+    default_output_location = "wlcg"
 
     def __init__(self, *args, **kwargs):
         # cached bash sandbox that wraps the cmssw environment
@@ -305,7 +308,7 @@ class BundleCMSSW(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLocalFile
 
     def single_output(self):
         cmssw_path = os.path.basename(self.get_cmssw_path())
-        return self.wlcg_target(f"{cmssw_path}.{self.checksum}.tgz")
+        return self.target(f"{cmssw_path}.{self.checksum}.tgz")
 
     def output(self):
         return law.tasks.TransferLocalFile.output(self)

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -76,10 +76,10 @@ class CreateHistograms(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return self.local_target(f"histograms_vars_{self.variables_repr}_{self.branch}.pickle")
+        return self.target(f"histograms_vars_{self.variables_repr}_{self.branch}.pickle")
 
+    @law.decorator.localize(input=True, output=False)
     @law.decorator.safe_output
-    @law.decorator.localize
     def run(self):
         import hist
         import numpy as np
@@ -227,7 +227,7 @@ class MergeHistograms(
         ]
 
     def merge_output(self):
-        return self.local_target(f"histograms_vars_{self.variables_repr}.pickle")
+        return self.target(f"histograms_vars_{self.variables_repr}.pickle")
 
     def merge(self, inputs, output):
         inputs_list = [inp.load(formatter="pickle") for inp in inputs]
@@ -314,7 +314,7 @@ class MergeShiftedHistograms(
         return parts
 
     def output(self):
-        return self.local_target(f"shifted_histograms_vars_{self.variables_repr}.pickle")
+        return self.target(f"shifted_histograms_vars_{self.variables_repr}.pickle")
 
     def run(self):
         with self.publish_step(f"merging shift sources {', '.join(self.shift_sources)} ..."):

--- a/ap/tasks/inference.py
+++ b/ap/tasks/inference.py
@@ -89,12 +89,12 @@ class CreateDatacards(
         basename = lambda name, ext: f"{name}__cat_{cat_obj.category}__var_{cat_obj.variable}.{ext}"
 
         return {
-            "card": self.local_target(basename("datacard", "txt")),
-            "shapes": self.local_target(basename("shapes", "root")),
+            "card": self.target(basename("datacard", "txt")),
+            "shapes": self.target(basename("shapes", "root")),
         }
 
+    @law.decorator.localize(input=False, output=True)
     @law.decorator.safe_output
-    @law.decorator.localize(output=False)
     def run(self):
         import hist
         from ap.inference.datacard import DatacardWriter

--- a/ap/tasks/inference.py
+++ b/ap/tasks/inference.py
@@ -29,6 +29,10 @@ class CreateDatacards(
 
     sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
 
+    # default upstream dependency task classes
+    dep_MergeHistograms = MergeHistograms
+    dep_MergeShiftedHistograms = MergeShiftedHistograms
+
     def create_branch_map(self):
         return list(self.inference_model_inst.categories)
 
@@ -49,7 +53,7 @@ class CreateDatacards(
         cat_obj = self.branch_data
         reqs = {
             proc_obj.name: {
-                dataset: MergeShiftedHistograms.req(
+                dataset: self.dep_MergeShiftedHistograms.req(
                     self,
                     dataset=dataset,
                     shift_sources=tuple(
@@ -67,7 +71,7 @@ class CreateDatacards(
         }
         if cat_obj.data_datasets:
             reqs["data"] = {
-                dataset: MergeHistograms.req(
+                dataset: self.dep_MergeHistograms.req(
                     self,
                     dataset=dataset,
                     variables=(cat_obj.variable,),

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -50,6 +50,9 @@ class PlotVariables(
 
     shifts = set(MergeHistograms.shifts)
 
+    # default upstream dependency task classes
+    dep_MergeHistograms = MergeHistograms
+
     # default plot function
     plot_function_name = "ap.plotting.variables.plot_variables"
 
@@ -66,11 +69,12 @@ class PlotVariables(
             return reqs
 
         reqs["merged_hists"] = self.requires_from_branch()
+
         return reqs
 
     def requires(self):
         return {
-            d: MergeHistograms.req(
+            d: self.dep_MergeHistograms.req(
                 self,
                 dataset=d,
                 branch=-1,
@@ -180,6 +184,9 @@ class PlotShiftedVariables(
 
     sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
+    # default upstream dependency task classes
+    dep_MergeShiftedHistograms = MergeShiftedHistograms
+
     # default plot function
     plot_function_name = "ap.plotting.variables.plot_shifted_variables"
 
@@ -206,7 +213,7 @@ class PlotShiftedVariables(
 
     def requires(self):
         return {
-            d: MergeShiftedHistograms.req(
+            d: self.dep_MergeShiftedHistograms.req(
                 self,
                 dataset=d,
                 branch=-1,

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -87,7 +87,7 @@ class PlotVariables(
 
     def output(self):
         b = self.branch_data
-        return self.local_target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
+        return self.target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
 
     @PlotMixin.view_output_plots
     def run(self):
@@ -225,7 +225,7 @@ class PlotShiftedVariables(
 
     def output(self):
         b = self.branch_data
-        return self.local_target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
+        return self.target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
 
     @PlotMixin.view_output_plots
     def run(self):

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -26,19 +26,22 @@ class ProduceColumns(
 
     shifts = set(MergeReducedEvents.shifts)
 
+    # default upstream dependency task classes
+    dep_MergeReducedEvents = MergeReducedEvents
+
     def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
         if only_super:
             return reqs
 
-        reqs["events"] = MergeReducedEvents.req(self, _exclude={"branches"})
+        reqs["events"] = self.dep_MergeReducedEvents.req(self, _exclude={"branches"})
         reqs["producer"] = self.producer_inst.run_requires()
 
         return reqs
 
     def requires(self):
         return {
-            "events": MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+            "events": self.dep_MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
             "producer": self.producer_inst.run_requires(),
         }
 

--- a/ap/tasks/production.py
+++ b/ap/tasks/production.py
@@ -47,10 +47,10 @@ class ProduceColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return self.local_target(f"columns_{self.branch}.parquet")
+        return self.target(f"columns_{self.branch}.parquet")
 
-    @law.decorator.safe_output
     @law.decorator.localize
+    @law.decorator.safe_output
     def run(self):
         from ap.columnar_util import (
             RouteFilter, ChunkedReader, mandatory_coffea_columns, sorted_ak_to_parquet,

--- a/ap/tasks/reduction.py
+++ b/ap/tasks/reduction.py
@@ -57,11 +57,11 @@ class ReduceEvents(DatasetTask, SelectorStepsMixin, CalibratorsMixin, law.LocalW
         }
 
     def output(self):
-        return self.local_target(f"events_{self.branch}.parquet")
+        return self.target(f"events_{self.branch}.parquet")
 
-    @law.decorator.safe_output
-    @law.decorator.localize
     @ensure_proxy
+    @law.decorator.localize
+    @law.decorator.safe_output
     def run(self):
         from ap.columnar_util import (
             Route, RouteFilter, ChunkedReader, mandatory_coffea_columns, update_ak_array,
@@ -206,7 +206,7 @@ class MergeReductionStats(DatasetTask, SelectorStepsMixin, CalibratorsMixin):
         return self.dep_ReduceEvents.req(self, branches=((0, self.n_inputs),))
 
     def output(self):
-        return self.local_target(f"stats_n{self.n_inputs}.json")
+        return self.target(f"stats_n{self.n_inputs}.json")
 
     @law.decorator.safe_output
     def run(self):
@@ -315,7 +315,7 @@ class MergeReducedEventsUser(DatasetTask):
 
     def reduced_dummy_output(self):
         # dummy output to be returned in case the merging stats are not present yet
-        return self.local_target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
+        return self.target("DUMMY_UNTIL_REDUCED_MERGING_STATS_EXIST")
 
     @classmethod
     def maybe_dummy(cls, func):
@@ -379,7 +379,7 @@ class MergeReducedEvents(
         # use the branch_map defined in DatasetTask to compute the number of files after merging
         n_merged = len(DatasetTask.create_branch_map(self))
         return law.SiblingFileCollection([
-            self.local_target(f"events_{i}.parquet")
+            self.target(f"events_{i}.parquet")
             for i in range(n_merged)
         ])
 

--- a/ap/tasks/selection.py
+++ b/ap/tasks/selection.py
@@ -63,19 +63,19 @@ class SelectEvents(DatasetTask, SelectorMixin, CalibratorsMixin, law.LocalWorkfl
 
     def output(self):
         outputs = {
-            "results": self.local_target(f"results_{self.branch}.parquet"),
-            "stats": self.local_target(f"stats_{self.branch}.json"),
+            "results": self.target(f"results_{self.branch}.parquet"),
+            "stats": self.target(f"stats_{self.branch}.json"),
         }
 
         # add additional columns in case the selector produces some
         if self.selector_inst.produced_columns:
-            outputs["columns"] = self.local_target(f"columns_{self.branch}.parquet")
+            outputs["columns"] = self.target(f"columns_{self.branch}.parquet")
 
         return outputs
 
-    @law.decorator.safe_output
-    @law.decorator.localize
     @ensure_proxy
+    @law.decorator.localize
+    @law.decorator.safe_output
     def run(self):
         from ap.columnar_util import (
             Route, RouteFilter, ChunkedReader, mandatory_coffea_columns, update_ak_array,
@@ -206,7 +206,7 @@ class MergeSelectionStats(DatasetTask, SelectorMixin, CalibratorsMixin, law.task
         ]
 
     def merge_output(self):
-        return self.local_target("stats.json")
+        return self.target("stats.json")
 
     def merge(self, inputs, output):
         # merge input stats

--- a/law.cfg
+++ b/law.cfg
@@ -27,6 +27,9 @@ ml_modules: ap.ml.test
 inference_modules: ap.inference.test
 
 
+[outputs]
+
+
 [job]
 
 job_file_dir: $AP_JOB_BASE

--- a/law.cfg
+++ b/law.cfg
@@ -20,6 +20,10 @@ ap.tasks.cutflow
 
 [analysis]
 
+default_analysis: analysis_st
+default_config: run2_pp_2018
+default_dataset: st_tchannel_t
+
 production_modules: ap.production.{categories,processes,features,pileup,normalization,seeds,weights}
 calibration_modules: ap.calibration.{test,jets}
 selection_modules: ap.selection.test


### PR DESCRIPTION
This PR contains a first set of changes related to the generalization ahead of the "core" separation. There are three types of changes:

1. The name of the analysis is no longer a class member on `AnalysisTask`, but rather a Parameter.
2. The task classes of dependencies are now stored on every task as `dep_TheRequiredTask` and used in the `requires()` as `self.dep_TheRequiredTask.req(self, ...)`. By doing so, analysis repositories can sub class core tasks and easily change their requirements without having to overwrite the full `requires()` method. It might not be avoidable in all cases, but just changing `dep_TheRequiredTask` to another class might fit many use cases.
3. The tasks no longer define their outputs as `self.local_target()`. Instead, there is a more generic `self.target()` method now, that forwards the call to either `self.local_target()` or `self.wlcg_target()`. The decision involves a task settings and optionally also options of the law.cfg file (see the new `OutputLocation` enum).