### PR TITLE
Feature/plotting parameters

### DIFF
--- a/ap/config/variables.py
+++ b/ap/config/variables.py
@@ -76,6 +76,7 @@ def add_variables(config: od.Config) -> None:
         binning=(40, 0., 400.),
         unit="GeV",
         x_title=r"Jet 2 $p_{T}$",
+        log_y=True,
     )
     config.add_variable(
         name="jet3_pt",

--- a/ap/plotting/plotter.py
+++ b/ap/plotting/plotter.py
@@ -104,7 +104,15 @@ def draw_errorbars(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> N
     ax.errorbar(**defaults)
 
 
-def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.Figure:
+def plot_all(
+    plot_config: dict,
+    style_config: dict,
+    skip_ratio: bool = False,
+    shape_norm: bool = False,
+    skip_legend: bool = False,
+    skip_cms: bool = False,
+    **kwargs,
+) -> plt.Figure:
     """
     plot_config expects dictionaries with fields:
     "method": str, identical to the name of a function defined above,
@@ -127,7 +135,7 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
     plt.style.use(mplhep.style.CMS)
 
     rax = None
-    if ratio:
+    if not skip_ratio:
         fig, (ax, rax) = plt.subplots(2, 1, gridspec_kw=dict(height_ratios=[3, 1], hspace=0), sharex=True)
     else:
         fig, ax = plt.subplots()
@@ -144,7 +152,7 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
         kwargs = cfg.get("kwargs", {})
         plot_methods[method](ax, hist, **kwargs)
 
-        if ratio and "ratio_kwargs" in cfg:
+        if not skip_ratio and "ratio_kwargs" in cfg:
             # take ratio_method if the ratio plot requires a different plotting method
             method = cfg.get("ratio_method", method)
             plot_methods[method](rax, hist, **cfg["ratio_kwargs"])
@@ -160,7 +168,7 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
         ax_kwargs["ylim"] = 0.000001
     ax.set(**ax_kwargs)
 
-    if ratio:
+    if not skip_ratio:
         # hard-coded line at 1
         rax.axhline(y=1.0, linestyle="dashed", color="gray")
         rax_kwargs = {
@@ -174,19 +182,23 @@ def plot_all(plot_config: dict, style_config: dict, ratio: bool = True) -> plt.F
         fig.align_ylabels()
 
     # legend
-    legend_kwargs = {
-        "ncol": 1,
-        "loc": "upper right",
-    }
-    legend_kwargs.update(style_config.get("legend_cfg", {}))
-    ax.legend(**legend_kwargs)
+    if not skip_legend:
+        legend_kwargs = {
+            "ncol": 1,
+            "loc": "upper right",
+        }
+        legend_kwargs.update(style_config.get("legend_cfg", {}))
+        ax.legend(**legend_kwargs)
 
     cms_label_kwargs = {
         "ax": ax,
+        "loc": 2,
         "llabel": "Work in progress",
         "fontsize": 22,
     }
     cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
+    if skip_cms:
+        cms_label_kwargs.update({"data": True, "llabel": "", "exp": ""})
     mplhep.cms.label(**cms_label_kwargs)
 
     plt.tight_layout()

--- a/ap/plotting/plotter.py
+++ b/ap/plotting/plotter.py
@@ -163,9 +163,16 @@ def plot_all(
         "xlabel": "variable",
         "yscale": "linear",
     }
+
+    # some default ylim settings based on yscale
+    log_y = style_config.get("ax_cfg", {}).get("yscale", "linear") == "log"
+    ax_ymax = ax.get_ylim()[1]
+    ax_ylim = (ax_ymax / 10**4, ax_ymax * 40) if log_y else (0.00001, ax_ymax * 1.2)
+    ax_kwargs.update({"ylim": ax_ylim})
+
+    # prioritize style_config ax settings
     ax_kwargs.update(style_config.get("ax_cfg", {}))
-    if ax_kwargs["yscale"] == "linear":
-        ax_kwargs["ylim"] = 0.000001
+
     ax.set(**ax_kwargs)
 
     if not skip_ratio:
@@ -189,16 +196,18 @@ def plot_all(
         }
         legend_kwargs.update(style_config.get("legend_cfg", {}))
         ax.legend(**legend_kwargs)
-
+    print(mplhep.__version__)
     cms_label_kwargs = {
         "ax": ax,
         "loc": 2,
         "llabel": "Work in progress",
         "fontsize": 22,
     }
+    # TODO: set "data": False when there are no data histograms (adds 'Simulation' to CMS label)
     cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
     if skip_cms:
-        cms_label_kwargs.update({"data": True, "llabel": "", "exp": ""})
+        # TODO: "exp": "" does not work with this mplhep version (0.3.12), but works with 0.3.23
+        cms_label_kwargs.update({"data": True, "llabel": ""})
     mplhep.cms.label(**cms_label_kwargs)
 
     plt.tight_layout()

--- a/ap/plotting/variables.py
+++ b/ap/plotting/variables.py
@@ -4,6 +4,8 @@
 Scripts to create plots using the plotter
 """
 
+from law import NO_STR
+
 from collections import OrderedDict
 from typing import Sequence, Optional
 
@@ -23,6 +25,7 @@ def plot_variables(
     config_inst: od.config,
     variable_inst: od.variable,
     style_config: Optional[dict] = None,
+    **kwargs,
 ) -> plt.Figure:
 
     # create the stack and a fake data hist using the smeared sum
@@ -70,11 +73,16 @@ def plot_variables(
             "ratio_kwargs": {"norm": h_mc.values()},
         }
 
+    yscale = kwargs.get("yscale", "linear")
+    if yscale == NO_STR:
+        yscale = "log" if variable_inst.log_y else "linear"
+
     default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
             "xlabel": variable_inst.get_full_x_title(),
+            "yscale": yscale,
         },
         "rax_cfg": {
             "ylabel": "Data / MC",
@@ -87,8 +95,7 @@ def plot_variables(
     }
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
 
-    fig = plot_all(plot_config, style_config, ratio=True)
-
+    fig = plot_all(plot_config, style_config, **kwargs)
     return fig
 
 
@@ -98,6 +105,7 @@ def plot_shifted_variables(
     process_inst: od.process,
     variable_inst: od.variable,
     style_config: Optional[dict] = None,
+    **kwargs,
 ) -> plt.Figure:
 
     # create the stack and the sum
@@ -118,10 +126,15 @@ def plot_shifted_variables(
         },
     }
 
+    yscale = kwargs.get("yscale", "linear")
+    if yscale == NO_STR:
+        yscale = "log" if variable_inst.log_y else "linear"
+
     default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
+            "yscale": yscale,
         },
         "rax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
@@ -139,7 +152,6 @@ def plot_shifted_variables(
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
 
     fig = plot_all(plot_config, style_config, ratio=True)
-
     return fig
 
 
@@ -147,6 +159,7 @@ def plot_cutflow(
     hists: OrderedDict,
     config_inst: od.config,
     style_config: Optional[dict] = None,
+    **kwargs,
 ) -> plt.Figure:
 
     mc_hists = [h for process_inst, h in hists.items() if process_inst.is_mc]
@@ -172,10 +185,14 @@ def plot_cutflow(
             },
         },
     }
+
+    yscale = kwargs.get("yscale", "linear")
+
     default_style_config = {
         "ax_cfg": {
             "ylabel": "Selection efficiency",
             "xlabel": "Selection steps",
+            "yscale": yscale,
         },
         "legend_cfg": {
             "loc": "upper right",
@@ -187,5 +204,4 @@ def plot_cutflow(
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
 
     fig = plot_all(plot_config, style_config, ratio=False)
-
     return fig

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -234,6 +234,9 @@ class PlotCutflow(
             for proc in process_insts
         }
 
+        # get plot style parameters
+        plot_kwargs = self.get_plot_parameters()
+
         # histogram data per process
         hists = {}
 
@@ -294,6 +297,8 @@ class PlotCutflow(
                 self.plot_function_name,
                 hists=hists,
                 config_inst=self.config_inst,
+                **plot_kwargs,
+
             )
 
             # save the plot
@@ -383,6 +388,9 @@ class PlotCutflowVariables(
             for proc in process_insts
         }
 
+        # get plot style parameters
+        plot_kwargs = self.get_plot_parameters()
+
         # histogram data per process
         hists = {}
 
@@ -451,6 +459,7 @@ class PlotCutflowVariables(
                     config_inst=self.config_inst,
                     variable_inst=variable_inst,
                     style_config={"legend_cfg": {"title": f"Step '{step}'"}},
+                    **plot_kwargs,
                 )
 
                 # save the plot

--- a/ap/tasks/cutflow.py
+++ b/ap/tasks/cutflow.py
@@ -385,9 +385,6 @@ class PlotCutflowVariables(
             for proc in process_insts
         }
 
-        # get plot style parameters
-        plot_kwargs = self.get_plot_parameters()
-
         # histogram data per process
         hists = {}
 
@@ -456,7 +453,7 @@ class PlotCutflowVariables(
                     config_inst=self.config_inst,
                     variable_inst=variable_inst,
                     style_config={"legend_cfg": {"title": f"Step '{step}'"}},
-                    **plot_kwargs,
+                    **self.get_plot_parameters(),
                 )
 
                 # save the plot

--- a/ap/tasks/framework/mixins.py
+++ b/ap/tasks/framework/mixins.py
@@ -718,6 +718,49 @@ class ShiftSourcesMixin(ConfigTask):
 
 class PlotMixin(AnalysisTask):
 
+    skip_ratio = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="boolean; when True, no ratio (usually Data/Bkg ratio) is drawn in the lower panel"
+        "default: False",
+    )
+
+    shape_norm = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="boolean; when True, each process is normalized on it's integral in the upper panel"
+        "default: False",
+    )
+    skip_legend = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="boolean; when True, no legend is drawn; default: False",
+    )
+    skip_cms = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="boolean; when True, no CMS logo is drawn; default: False",
+    )
+    # when no default is set, the choice should be made by the variable.y_log to decide between
+    # "linear" and "log"; for now, this is done in each plotting function individually
+    # Also: restrict this parameter to all possible choices? law.NO_STR, "log", "linear", ("symlog", "logit")
+    yscale = luigi.Parameter(
+        default=law.NO_STR,
+        significant=False,
+        description="string parameter to define the y scale (e.g. 'linear' or 'log') of the plot "
+        "in the upper panel; no default",
+    )
+
+    def get_plot_parameters(self):
+        kwargs = {
+            "skip_ratio": self.skip_ratio,
+            "shape_norm": self.shape_norm,
+            "skip_legend": self.skip_legend,
+            "skip_cms": self.skip_cms,
+            "yscale": self.yscale,
+        }
+        return kwargs
+
     view_cmd = luigi.Parameter(
         default=law.NO_STR,
         significant=False,

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -103,6 +103,9 @@ class PlotVariables(
             for proc in process_insts
         }
 
+        # get plot style parameters
+        plot_kwargs = self.get_plot_parameters()
+
         # histogram data per process
         hists = {}
 
@@ -164,6 +167,7 @@ class PlotVariables(
                 hists=hists,
                 config_inst=self.config_inst,
                 variable_inst=variable_inst,
+                **plot_kwargs,
             )
 
             # save the plot
@@ -241,6 +245,9 @@ class PlotShiftedVariables(
             for proc in process_insts
         }
 
+        # get plot style parameters
+        plot_kwargs = self.get_plot_parameters()
+
         # histogram data per process
         hists = OrderedDict()
 
@@ -292,6 +299,7 @@ class PlotShiftedVariables(
                 config_inst=self.config_inst,
                 process_inst=process_inst,
                 variable_inst=variable_inst,
+                **plot_kwargs,
             )
 
             # save the plot


### PR DESCRIPTION
This PR adds 5 new parameters to the `PlotMixin`:

- `skip_ratio` removes the lower panel
- `shape_norm` normalized the upper panel on it's integral (not used in PlotCutflow)
- `skip_legend` removes the legend
- `skip_cms` removes the CMS logo but keeps lumi (TODO: does not work due to the mplhep version)
- `yscale` allows setting the y scale to whatever you desire (default: whatever the config of the variable says)

In addition, some defaults for the ylim values are defined based on the chosen scale ("log" or "linear")

Example command for testing:
`law run PlotVariables --version test --processes tt_sl,st_tchannel --variables jet1_pt,ht --workers 6 --skip-ratio True --skip-legend True --skip-cms True --yscale log --shape-norm True`