### PR TITLE
Improve histogram merging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ The task that you are about to start requires a valid voms proxy.
     law run PlotVariables \
         --version v1 \
         --datasets "st_tchannel_t,tt_sl" \
-        --producers variables \
+        --producers features \
         --variables ht \
         --workers 3
 

--- a/ap/production/features.py
+++ b/ap/production/features.py
@@ -28,7 +28,7 @@ ak = maybe_import("awkward")
         jet_energy_shifts,
     },
 )
-def variables(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     set_ak_column(events, "ht", ak.sum(events.Jet.pt, axis=1))
     set_ak_column(events, "n_jet", ak.num(events.Jet.pt, axis=1))
     set_ak_column(events, "n_electron", ak.num(events.Electron.pt, axis=1))

--- a/ap/tasks/histograms.py
+++ b/ap/tasks/histograms.py
@@ -219,14 +219,16 @@ class MergeHistograms(
         if only_super:
             return reqs
 
-        reqs["hists"] = self.requires_from_branch()
+        reqs["hists"] = self.as_branch().requires()
 
         return reqs
 
     def requires(self):
         # optional dynamic behavior: determine not yet created variables and require only those
+        prefer_cli = {"variables"}
         variables = self.variables
         if self.only_missing:
+            prefer_cli.clear()
             missing = self.output().count(existing=False, keys=True)[1]
             variables = tuple(sorted(missing, key=variables.index))
             if not variables:
@@ -237,7 +239,7 @@ class MergeHistograms(
             branch=-1,
             variables=tuple(variables),
             _exclude={"branches"},
-            _prefer_cli={"variables"},
+            _prefer_cli=prefer_cli,
         )
 
     def output(self):

--- a/ap/tasks/plotting.py
+++ b/ap/tasks/plotting.py
@@ -15,7 +15,7 @@ from ap.tasks.framework.mixins import (
 )
 from ap.tasks.framework.remote import HTCondorWorkflow
 from ap.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from ap.util import DotDict, dev_sandbox
+from ap.util import DotDict
 
 
 class ProcessPlotBase(
@@ -46,7 +46,7 @@ class PlotVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
     shifts = set(MergeHistograms.shifts)
 
@@ -181,7 +181,7 @@ class PlotShiftedVariables(
     HTCondorWorkflow,
 ):
 
-    sandbox = dev_sandbox("bash::$AP_BASE/sandboxes/venv_columnar.sh")
+    sandbox = "bash::$AP_BASE/sandboxes/cmssw_default.sh"
 
     # default upstream dependency task classes
     dep_MergeShiftedHistograms = MergeShiftedHistograms


### PR DESCRIPTION
This PR adds new features to the `MergeHistograms` task.

- The output histograms are now split for different variables which should help with large file sizes in the future.
- There is a new flag `--only-missing` which only requires `CreateHistograms` and merges files for variables that have not been processed yet.
- There is a new flag `--remove-previous` which leads to the input files (outputs of `CreateHistograms`) being removed after they have been successfully merged.